### PR TITLE
refactor: replace deprecated grpc.DialContext with NewClient

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -310,11 +310,9 @@ func (h *Handler) callGetNodesGRPC(kubeconfigBase64 string) ([]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	conn, err := grpc.DialContext(
-		ctx,
+	conn, err := grpc.NewClient(
 		h.grpcServerAddr,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithBlock(),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description
Replace deprecated `grpc.DialContext` with `grpc.NewClient` in internal/api/handlers.go. 
https://pkg.go.dev/google.golang.org/grpc#section-readme:~:text=target%20string%20directly.-,Deprecated%3A%20use%20NewClient%20instead.%20Will%20be%20supported%20throughout%201.x.,-func%20NewClient%20%C2%B6

Fixes #1