### PR TITLE
fix: add context timeout to Kubernetes API calls

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -122,7 +122,8 @@ func (h *Handler) GetClusters(w http.ResponseWriter, r *http.Request) {
 // - New: ?targetUUID=<uuid>
 // - Legacy: ?id=<targetRequestId>&cluster-name=<clusterName>
 func (h *Handler) GetNodes(w http.ResponseWriter, r *http.Request) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
 	// New parameter (KrknOperatorTarget)
 	targetUUID := r.URL.Query().Get("targetUUID")
@@ -911,7 +912,8 @@ func (h *Handler) PostScenarioRun(w http.ResponseWriter, r *http.Request) {
 		seen[clusterName] = true
 	}
 
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
 	// Generate scenario run name
 	scenarioRunName := fmt.Sprintf("%s-%s", req.ScenarioName, uuid.New().String()[:8])
@@ -987,7 +989,8 @@ func (h *Handler) GetScenarioRunStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
 	// Fetch the KrknScenarioRun CR
 	var scenarioRun krknv1alpha1.KrknScenarioRun
@@ -1174,7 +1177,8 @@ func (h *Handler) GetScenarioRunLogs(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
 	// Find pod by jobId label (no need to fetch the CR)
 	var podList corev1.PodList
@@ -1295,7 +1299,8 @@ func (h *Handler) GetScenarioRunLogs(w http.ResponseWriter, r *http.Request) {
 // ListScenarioRuns handles GET /api/v1/scenarios/run endpoint
 // It returns a list of all scenario runs (KrknScenarioRun CRs)
 func (h *Handler) ListScenarioRuns(w http.ResponseWriter, r *http.Request) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
 	// Parse query parameters for filtering
 	phaseFilter := r.URL.Query().Get("phase")          // e.g., Running, Succeeded, Failed
@@ -1355,7 +1360,8 @@ func (h *Handler) DeleteScenarioRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
 	var podList corev1.PodList
 	if err := h.client.List(ctx, &podList, client.InNamespace(h.namespace), client.MatchingLabels{
@@ -1430,7 +1436,8 @@ func (h *Handler) DeleteScenarioRunComplete(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
 	// Fetch the KrknScenarioRun CR
 	var scenarioRun krknv1alpha1.KrknScenarioRun
@@ -1485,7 +1492,8 @@ func (h *Handler) DeleteSingleJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
 	// Find KrknScenarioRun containing this jobId
 	var scenarioRunList krknv1alpha1.KrknScenarioRunList
@@ -1587,7 +1595,8 @@ func (h *Handler) GetSingleJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
 	// Find KrknScenarioRun containing this jobId
 	var scenarioRunList krknv1alpha1.KrknScenarioRunList

--- a/internal/api/targets_crud.go
+++ b/internal/api/targets_crud.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
@@ -144,7 +145,8 @@ func generateKubeconfigFromCredentialsType(req CreateTargetRequest) (string, str
 // CreateTarget handles POST /api/v1/operator/targets
 // Creates a new KrknOperatorTarget CR with a generated UUID and associated Secret
 func (h *Handler) CreateTarget(w http.ResponseWriter, r *http.Request) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
 	// Parse request body
 	var req CreateTargetRequest
@@ -288,7 +290,8 @@ func (h *Handler) CreateTarget(w http.ResponseWriter, r *http.Request) {
 // ListTargets handles GET /api/v1/operator/targets
 // Returns a list of all KrknOperatorTarget CRs
 func (h *Handler) ListTargets(w http.ResponseWriter, r *http.Request) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
 	// List all targets
 	var targets krknv1alpha1.KrknOperatorTargetList
@@ -316,7 +319,8 @@ func (h *Handler) ListTargets(w http.ResponseWriter, r *http.Request) {
 // GetTarget handles GET /api/v1/operator/targets/{uuid}
 // Returns a single KrknOperatorTarget by UUID
 func (h *Handler) GetTarget(w http.ResponseWriter, r *http.Request) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
 	targetUUID, err := extractPathSuffix(r.URL.Path, "/api/v1/operator/targets/")
 	if err != nil {
@@ -340,7 +344,8 @@ func (h *Handler) GetTarget(w http.ResponseWriter, r *http.Request) {
 // UpdateTarget handles PUT /api/v1/operator/targets/{uuid}
 // Updates an existing KrknOperatorTarget (overwrites the Secret kubeconfig)
 func (h *Handler) UpdateTarget(w http.ResponseWriter, r *http.Request) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
 	targetUUID, err := extractPathSuffix(r.URL.Path, "/api/v1/operator/targets/")
 	if err != nil {
@@ -436,7 +441,8 @@ func (h *Handler) UpdateTarget(w http.ResponseWriter, r *http.Request) {
 // DeleteTarget handles DELETE /api/v1/operator/targets/{uuid}
 // Deletes a KrknOperatorTarget and its associated Secret
 func (h *Handler) DeleteTarget(w http.ResponseWriter, r *http.Request) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
 	targetUUID, err := extractPathSuffix(r.URL.Path, "/api/v1/operator/targets/")
 	if err != nil {


### PR DESCRIPTION
## Description
Replaced `context.Background()` with `context.WithTimeout(..., 30*time.Second)` in HTTP handlers and CRUD operations.

Prevents requests from hanging indefinitely if the Kubernetes API server is slow or unreachable.

Fixes #3 