### PR TITLE
fix(helm): add missing KrknGraphRun CRD to chart

### DIFF
--- a/charts/krkn-operator/crds/krkn.krkn-chaos.dev_krkngraphruns.yaml
+++ b/charts/krkn-operator/crds/krkn.krkn-chaos.dev_krkngraphruns.yaml
@@ -1,0 +1,290 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: krkngraphruns.krkn.krkn-chaos.dev
+spec:
+  group: krkn.krkn-chaos.dev
+  names:
+    kind: KrknGraphRun
+    listKind: KrknGraphRunList
+    plural: krkngraphruns
+    shortNames:
+    - kgr
+    singular: krkngraphrun
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.summary.totalNodes
+      name: Total
+      type: integer
+    - jsonPath: .status.summary.completedNodes
+      name: Completed
+      type: integer
+    - jsonPath: .status.summary.failedNodes
+      name: Failed
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KrknGraphRun is the Schema for the krkngraphruns API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KrknGraphRunSpec defines the desired state of KrknGraphRun
+            properties:
+              graph:
+                additionalProperties:
+                  description: |-
+                    GraphScenarioNode represents a node in the scenario dependency graph
+                    This mirrors krknctl's ScenarioNode struct but with explicit JSON tags for Kubernetes compatibility
+                  properties:
+                    _comment:
+                      description: Comment is an optional comment describing the scenario
+                      type: string
+                    depends_on:
+                      description: DependsOn is the node ID that this scenario depends
+                        on (parent in the graph)
+                      type: string
+                    env:
+                      additionalProperties:
+                        type: string
+                      description: Env is a map of environment variables for the scenario
+                      type: object
+                    image:
+                      description: Image is the container image for the scenario
+                      type: string
+                    name:
+                      description: Name is the name of the scenario
+                      type: string
+                    volumes:
+                      additionalProperties:
+                        type: string
+                      description: Volumes is a map of volume mounts for the scenario
+                      type: object
+                  type: object
+                description: |-
+                  Graph is the dependency graph of scenarios to execute
+                  Maps node ID to scenario node definition with dependencies
+                  This is compatible with krknctl ScenarioSet for 1:1 JSON compatibility
+                type: object
+              ownerUserId:
+                description: OwnerUserID is the email address of the user who created
+                  this graph run
+                type: string
+              targetClusters:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: |-
+                  TargetClusters is a map of provider-name to list of cluster names
+                  Example: {"krkn-operator": ["cluster1", "cluster2"], "krkn-operator-acm": ["cluster3"]}
+                minProperties: 1
+                type: object
+              targetRequestId:
+                description: TargetRequestID is the reference to the KrknTargetRequest
+                  CR
+                type: string
+            required:
+            - graph
+            - targetClusters
+            - targetRequestId
+            type: object
+          status:
+            description: KrknGraphRunStatus defines the observed state of KrknGraphRun
+            properties:
+              completionTime:
+                description: CompletionTime is when the graph run completed
+                format: date-time
+                type: string
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the graph run's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              nodeStatuses:
+                description: NodeStatuses contains the status of each node in the
+                  graph
+                items:
+                  description: NodeStatus represents the status of a single node in
+                    the dependency graph
+                  properties:
+                    completionTime:
+                      description: CompletionTime is when this node completed execution
+                      format: date-time
+                      type: string
+                    dependsOn:
+                      description: DependsOn is the list of node IDs that this node
+                        depends on
+                      items:
+                        type: string
+                      type: array
+                    message:
+                      description: Message contains additional information about the
+                        node status
+                      type: string
+                    nodeId:
+                      description: NodeID is the unique identifier for this node in
+                        the graph
+                      type: string
+                    nodeName:
+                      description: NodeName is the human-readable name of the scenario
+                      type: string
+                    phase:
+                      description: Phase is the current phase of this node
+                      enum:
+                      - Pending
+                      - Running
+                      - Completed
+                      - Failed
+                      - Blocked
+                      type: string
+                    scenarioRunRef:
+                      description: ScenarioRunRef is the reference to the KrknScenarioRun
+                        CR created for this node
+                      type: string
+                    startTime:
+                      description: StartTime is when this node started execution
+                      format: date-time
+                      type: string
+                  required:
+                  - nodeId
+                  - nodeName
+                  - phase
+                  type: object
+                type: array
+              phase:
+                description: Phase is the overall phase of the graph run
+                enum:
+                - Pending
+                - Running
+                - Completed
+                - Failed
+                - PartiallyFailed
+                type: string
+              resolvedLevels:
+                description: |-
+                  ResolvedLevels contains the pre-computed topological levels for frontend rendering
+                  Each inner array represents a level of nodes that can run in parallel
+                  Example: [["node1", "node2"], ["node3"], ["node4", "node5"]]
+                items:
+                  items:
+                    type: string
+                  type: array
+                type: array
+              startTime:
+                description: StartTime is when the graph run started
+                format: date-time
+                type: string
+              summary:
+                description: Summary contains aggregate statistics about the graph
+                  run
+                properties:
+                  completedNodes:
+                    description: CompletedNodes is the number of successfully completed
+                      nodes
+                    type: integer
+                  failedNodes:
+                    description: FailedNodes is the number of failed nodes
+                    type: integer
+                  pendingNodes:
+                    description: PendingNodes is the number of pending nodes (including
+                      blocked nodes)
+                    type: integer
+                  runningNodes:
+                    description: RunningNodes is the number of currently running nodes
+                    type: integer
+                  totalNodes:
+                    description: TotalNodes is the total number of nodes in the graph
+                    type: integer
+                required:
+                - completedNodes
+                - failedNodes
+                - pendingNodes
+                - runningNodes
+                - totalNodes
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/krkn-operator/templates/operator/rbac.yaml
+++ b/charts/krkn-operator/templates/operator/rbac.yaml
@@ -56,6 +56,7 @@ rules:
 - apiGroups:
   - krkn.krkn-chaos.dev
   resources:
+  - krkngraphruns
   - krknoperatortargetproviderconfigs
   - krknoperatortargetproviders
   - krknoperatortargets
@@ -74,6 +75,7 @@ rules:
 - apiGroups:
   - krkn.krkn-chaos.dev
   resources:
+  - krkngraphruns/status
   - krknoperatortargetproviderconfigs/status
   - krknoperatortargetproviders/status
   - krknoperatortargets/status
@@ -123,6 +125,7 @@ rules:
 - apiGroups:
   - krkn.krkn-chaos.dev
   resources:
+  - krkngraphruns
   - krknoperatortargetproviderconfigs
   - krknoperatortargetproviders
   - krknoperatortargets
@@ -141,6 +144,7 @@ rules:
 - apiGroups:
   - krkn.krkn-chaos.dev
   resources:
+  - krkngraphruns/status
   - krknoperatortargetproviderconfigs/status
   - krknoperatortargetproviders/status
   - krknoperatortargets/status
@@ -155,6 +159,7 @@ rules:
 - apiGroups:
   - krkn.krkn-chaos.dev
   resources:
+  - krkngraphruns/finalizers
   - krknoperatortargetproviderconfigs/finalizers
   - krknoperatortargetproviders/finalizers
   - krknoperatortargets/finalizers


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

fix(helm): include KrknGraphRun CRD and RBAC in chart
<code>🐞 Bug fix</code> <code>⚙️ Configuration changes</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

The KrknGraphRun CRD was generated but never committed to git, causing the operator to fail at startup with "no matches for kind KrknGraphRun". This commit adds the missing CRD file and the associated RBAC permissions.

Fixes: tsebastiani-unq7

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Add missing KrknGraphRun CRD to Helm chart to prevent operator startup failure.
• Extend operator RBAC to manage KrknGraphRun resources, status, and finalizers.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  H["Helm chart"] --> CRD["KrknGraphRun CRD"] --> KAPI[("Kubernetes API")]
  H --> RBAC["RBAC rules"] --> SA["Operator ServiceAccount"] --> OP["krkn-operator"] --> KAPI
  OP --> RES["KrknGraphRun objects"] --> KAPI

  subgraph Legend
    direction LR
    _chart["Chart"] ~~~ _cfg["YAML config"] ~~~ _k8s[("K8s API")]
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Add CI guard to ensure generated CRDs are committed</b></summary>

- ➕ Prevents repeats of &#x27;generated but not committed&#x27; CRD drift
- ➕ Fails fast before release/publish
- ➖ Requires CI plumbing and a clear source-of-truth generation step
- ➖ Does not fix already-broken published charts by itself

</details>

<details>
<summary><b>2. Template CRDs via Helm templates (hooks or regular manifests)</b></summary>

- ➕ Allows conditional installation and templated metadata/labels
- ➕ Can align CRD delivery with other chart resources
- ➖ Helm CRD templating is discouraged/limited; upgrades can be tricky
- ➖ More operational risk than using the dedicated crds/ directory

</details>

**Recommendation:** The chosen approach (adding the missing CRD under charts/.../crds and updating RBAC) is the correct and lowest-risk fix for the startup failure. Consider a follow-up CI check to assert controller-gen outputs match committed CRDs to prevent future omissions.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>krkn.krkn-chaos.dev_krkngraphruns.yaml</strong> <code>Add KrknGraphRun CRD manifest (v1alpha1)</code> <code>+290/-0</code></summary>

<br/>

>Add KrknGraphRun CRD manifest (v1alpha1)
>
><pre>
>• Introduces the missing CustomResourceDefinition for KrknGraphRun, including OpenAPI schema, status subresource, and printer columns. This ensures the API server recognizes KrknGraphRun so the operator can start and reconcile it.
></pre>
>
><a href='https://github.com/krkn-chaos/krkn-operator/pull/17/files#diff-6f9f3e7bb9e028f92c9fb6975184092c9b7fdd50584527e92771f66a13758e26'>charts/krkn-operator/crds/krkn.krkn-chaos.dev_krkngraphruns.yaml</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Other</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>rbac.yaml</strong> <code>Grant RBAC for KrknGraphRun resource, status, and finalizers</code> <code>+5/-0</code></summary>

<br/>

>Grant RBAC for KrknGraphRun resource, status, and finalizers
>
><pre>
>• Adds KrknGraphRun permissions to the operator&#x27;s RBAC rules, including access to the main resource, its /status subresource, and /finalizers. This aligns runtime permissions with the newly installed CRD.
></pre>
>
><a href='https://github.com/krkn-chaos/krkn-operator/pull/17/files#diff-98ed3027e490d8a97cf820b5d032881c659d49606e08bb8d337f18e01c13d869'>charts/krkn-operator/templates/operator/rbac.yaml</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>