### PR TITLE
fix typo in deployment guide's architecture section

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -2,7 +2,7 @@
 
 This guide explains how to build, push, and deploy the krkn-operator using the standardized Makefile.
 
-## Architecturpuoi ce
+## Architecture
 
 The krkn-operator consists of two components running in a single pod:
 


### PR DESCRIPTION
Fixed the typo in the deployment guide from "Architecturpuoi ce" to "Architecture" in the first section. 