### PR TITLE
feat(status): populate KrknScenarioRun status conditions

### DIFF
--- a/internal/controller/krknscenariorun_controller.go
+++ b/internal/controller/krknscenariorun_controller.go
@@ -31,6 +31,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -1064,6 +1065,78 @@ func (r *KrknScenarioRunReconciler) calculateOverallStatus(scenarioRun *krknv1al
 		// Some succeeded, some failed
 		scenarioRun.Status.Phase = "PartiallyFailed"
 	}
+
+	// Populate status conditions derived from the overall phase so that
+	// `kubectl describe` and clients can observe the run state. The conditions
+	// are written onto the same status object that gets persisted, so the
+	// existing statusEqual diff prevents update loops.
+	setStatusConditions(scenarioRun)
+}
+
+// setStatusConditions derives the Ready/Progressing/Failed conditions from the
+// overall phase and job counters and applies them to the scenario run's status
+// via meta.SetStatusCondition (which preserves LastTransitionTime when a
+// condition's status is unchanged).
+func setStatusConditions(scenarioRun *krknv1alpha1.KrknScenarioRun) {
+	for _, condition := range buildStatusConditions(scenarioRun) {
+		meta.SetStatusCondition(&scenarioRun.Status.Conditions, condition)
+	}
+}
+
+// buildStatusConditions is a pure helper that computes the set of conditions
+// for the current status. It is kept side-effect free so it can be unit tested
+// without a cluster.
+func buildStatusConditions(scenarioRun *krknv1alpha1.KrknScenarioRun) []metav1.Condition {
+	status := &scenarioRun.Status
+	phase := status.Phase
+	generation := scenarioRun.Generation
+
+	countsMessage := fmt.Sprintf("%d succeeded, %d failed, %d running out of %d job(s)",
+		status.SuccessfulJobs, status.FailedJobs, status.RunningJobs, len(status.ClusterJobs))
+
+	// Ready is True only once every job has succeeded.
+	ready := metav1.Condition{
+		Type:               "Ready",
+		Status:             metav1.ConditionFalse,
+		Reason:             "JobsIncomplete",
+		Message:            countsMessage,
+		ObservedGeneration: generation,
+	}
+	if phase == "Succeeded" {
+		ready.Status = metav1.ConditionTrue
+		ready.Reason = "AllJobsSucceeded"
+	}
+
+	// Progressing is True while the run is still pending or actively running.
+	progressing := metav1.Condition{
+		Type:               "Progressing",
+		Status:             metav1.ConditionFalse,
+		Reason:             "RunComplete",
+		Message:            countsMessage,
+		ObservedGeneration: generation,
+	}
+	if phase == "Pending" || phase == "Running" {
+		progressing.Status = metav1.ConditionTrue
+		progressing.Reason = "JobsInProgress"
+	}
+
+	// Failed is True when the run finished with at least one failed job.
+	failed := metav1.Condition{
+		Type:               "Failed",
+		Status:             metav1.ConditionFalse,
+		Reason:             "NoJobFailures",
+		Message:            countsMessage,
+		ObservedGeneration: generation,
+	}
+	if phase == "Failed" {
+		failed.Status = metav1.ConditionTrue
+		failed.Reason = "AllJobsFailed"
+	} else if phase == "PartiallyFailed" {
+		failed.Status = metav1.ConditionTrue
+		failed.Reason = "SomeJobsFailed"
+	}
+
+	return []metav1.Condition{ready, progressing, failed}
 }
 
 // getKubeconfigFromProvider retrieves kubeconfig from a provider-specific Secret

--- a/internal/controller/krknscenariorun_controller_conditions_test.go
+++ b/internal/controller/krknscenariorun_controller_conditions_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Assisted-by: Claude Opus 4.8 (claude-opus-4-8)
+*/
+
+package controller
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	krknv1alpha1 "github.com/krkn-chaos/krkn-operator/api/v1alpha1"
+)
+
+// expectedCondition captures the fields we assert for a single condition.
+type expectedCondition struct {
+	status metav1.ConditionStatus
+	reason string
+}
+
+func TestBuildStatusConditions(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterJobs []krknv1alpha1.ClusterJobStatus
+		// expected keyed by condition Type
+		expected map[string]expectedCondition
+	}{
+		{
+			name:        "pending run with no jobs",
+			clusterJobs: nil,
+			expected: map[string]expectedCondition{
+				"Ready":       {metav1.ConditionFalse, "JobsIncomplete"},
+				"Progressing": {metav1.ConditionTrue, "JobsInProgress"},
+				"Failed":      {metav1.ConditionFalse, "NoJobFailures"},
+			},
+		},
+		{
+			name: "running with jobs in progress",
+			clusterJobs: []krknv1alpha1.ClusterJobStatus{
+				{ClusterName: "c1", Phase: "Running"},
+				{ClusterName: "c2", Phase: "Succeeded"},
+			},
+			expected: map[string]expectedCondition{
+				"Ready":       {metav1.ConditionFalse, "JobsIncomplete"},
+				"Progressing": {metav1.ConditionTrue, "JobsInProgress"},
+				"Failed":      {metav1.ConditionFalse, "NoJobFailures"},
+			},
+		},
+		{
+			name: "all jobs succeeded",
+			clusterJobs: []krknv1alpha1.ClusterJobStatus{
+				{ClusterName: "c1", Phase: "Succeeded"},
+				{ClusterName: "c2", Phase: "Succeeded"},
+			},
+			expected: map[string]expectedCondition{
+				"Ready":       {metav1.ConditionTrue, "AllJobsSucceeded"},
+				"Progressing": {metav1.ConditionFalse, "RunComplete"},
+				"Failed":      {metav1.ConditionFalse, "NoJobFailures"},
+			},
+		},
+		{
+			name: "all jobs failed",
+			clusterJobs: []krknv1alpha1.ClusterJobStatus{
+				{ClusterName: "c1", Phase: "Failed"},
+				{ClusterName: "c2", Phase: "MaxRetriesExceeded"},
+			},
+			expected: map[string]expectedCondition{
+				"Ready":       {metav1.ConditionFalse, "JobsIncomplete"},
+				"Progressing": {metav1.ConditionFalse, "RunComplete"},
+				"Failed":      {metav1.ConditionTrue, "AllJobsFailed"},
+			},
+		},
+		{
+			name: "partially failed run",
+			clusterJobs: []krknv1alpha1.ClusterJobStatus{
+				{ClusterName: "c1", Phase: "Succeeded"},
+				{ClusterName: "c2", Phase: "Failed"},
+			},
+			expected: map[string]expectedCondition{
+				"Ready":       {metav1.ConditionFalse, "JobsIncomplete"},
+				"Progressing": {metav1.ConditionFalse, "RunComplete"},
+				"Failed":      {metav1.ConditionTrue, "SomeJobsFailed"},
+			},
+		},
+	}
+
+	r := &KrknScenarioRunReconciler{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scenarioRun := &krknv1alpha1.KrknScenarioRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-scenario",
+					Namespace:  "default",
+					Generation: 7,
+				},
+				Status: krknv1alpha1.KrknScenarioRunStatus{
+					ClusterJobs: tt.clusterJobs,
+				},
+			}
+
+			// calculateOverallStatus computes counters, phase, and conditions.
+			r.calculateOverallStatus(scenarioRun)
+
+			conditions := scenarioRun.Status.Conditions
+			if len(conditions) != len(tt.expected) {
+				t.Fatalf("expected %d conditions, got %d: %+v",
+					len(tt.expected), len(conditions), conditions)
+			}
+
+			for condType, want := range tt.expected {
+				got := findCondition(conditions, condType)
+				if got == nil {
+					t.Errorf("missing condition %q", condType)
+					continue
+				}
+				if got.Status != want.status {
+					t.Errorf("condition %q: expected status %q, got %q",
+						condType, want.status, got.Status)
+				}
+				if got.Reason != want.reason {
+					t.Errorf("condition %q: expected reason %q, got %q",
+						condType, want.reason, got.Reason)
+				}
+				// Reason must be non-empty CamelCase (k8s requirement).
+				if got.Reason == "" {
+					t.Errorf("condition %q: reason must not be empty", condType)
+				}
+				if got.ObservedGeneration != scenarioRun.Generation {
+					t.Errorf("condition %q: expected ObservedGeneration %d, got %d",
+						condType, scenarioRun.Generation, got.ObservedGeneration)
+				}
+				if got.LastTransitionTime.IsZero() {
+					t.Errorf("condition %q: LastTransitionTime should be set", condType)
+				}
+			}
+		})
+	}
+}
+
+func findCondition(conditions []metav1.Condition, condType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == condType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
### What I did
I added the standard `Ready` / `Progressing` / `Failed` conditions to `KrknScenarioRun.status`, derived from the overall phase and job counters we already compute. This is the thing I was missing when I couldn't `kubectl wait` on a run — now I can.

### How it works

- I pulled the mapping into a pure `buildStatusConditions()` helper so I could unit-test every phase without spinning up a cluster.
- setStatusConditions() applies them with `meta.SetStatusCondition`, which keeps `lastTransitionTime` stable when a condition's status doesn't actually change.
- I hooked it into the end of `calculateOverallStatus`, so it rides on the same status object that already gets persisted. The existing `statusEqual` check keeps it from causing update loops.

Below is the ss of mapping I settled on:
<img width="789" height="170" alt="image" src="https://github.com/user-attachments/assets/d4c2788e-cd26-46b5-a027-7d2d0ec0002c" />

### How I tested it
Unit test — every phase mapping, no cluster needed:
```
=== RUN   TestBuildStatusConditions
    --- PASS: pending_run_with_no_jobs
    --- PASS: running_with_jobs_in_progress
    --- PASS: all_jobs_succeeded
    --- PASS: all_jobs_failed
    --- PASS: partially_failed_run
--- PASS: TestBuildStatusConditions (0.00s)
ok  github.com/krkn-chaos/krkn-operator/internal/controller  1.070s
```

Full suite (make test, envtest) — green, nothing else broke:
```
ok  internal/controller   coverage: 38.0%
ok  internal/api          coverage: 40.3%
ok  internal/kubeconfig   coverage: 85.2%
ok  api/v1alpha1, cmd, pkg/...  (all pass)
```

Then I ran it for real on a kind cluster (`make install` + `make run`) and applied a scenario run. The live controller wrote the conditions straight to the API server:
```
$ kubectl get krknscenariorun conditions-demo -o jsonpath='{.status.conditions}'
[
  {"type":"Ready",      "status":"False","reason":"JobsIncomplete", "observedGeneration":1,
   "message":"0 succeeded, 0 failed, 0 running out of 0 job(s)"},
  {"type":"Progressing","status":"True", "reason":"JobsInProgress", "observedGeneration":1,
   "message":"0 succeeded, 0 failed, 0 running out of 0 job(s)"},
  {"type":"Failed",     "status":"False","reason":"NoJobFailures",  "observedGeneration":1,
   "message":"0 succeeded, 0 failed, 0 running out of 0 job(s)"}
]
```

And the whole reason I started this — it works now:
```
$ kubectl wait --for=condition=Progressing krknscenariorun/conditions-demo
krknscenariorun.krkn.krkn-chaos.dev/conditions-demo condition met
```

I also checked it doesn't cause churn: the status only got written once for the object, so statusEqual is doing its job and we're not in a reconcile loop.

Two things I would like to shed light on:

1. My live test only hit the `Pending` phase. To drive a real `Succeeded`/`Failed`/`PartiallyFailed` transition I'd need the full target/provider + kubeconfig-secret setup, which I didn't have in a bare kind cluster. Those branches are all covered by the unit test, but I haven't watched them flip on a live object.
2. `PartiallyFailed` semantics. I chose to report it as `Ready=False`, `Progressing=False`, `Failed=True` with reason `SomeJobsFailed`. I didn't add a separate "partial success" condition. If you'd rather partial runs read differently, say so and I'll adjust.


Fixes #20