### PR TITLE
refactor(controller): extract pure buildScenarioPod and buildJobLabels

### DIFF
--- a/internal/controller/krknscenariorun_controller.go
+++ b/internal/controller/krknscenariorun_controller.go
@@ -71,9 +71,6 @@ type preparedJobResources struct {
 	clusterAPIURL     string
 	containerImage    string
 	kubeconfigPath    string
-	volumes           []corev1.Volume
-	volumeMounts      []corev1.VolumeMount
-	envVars           []corev1.EnvVar
 	imagePullSecrets  []corev1.LocalObjectReference
 	createdConfigMaps []string // names of created ConfigMaps for cleanup
 	createdSecrets    []string // names of created Secrets for cleanup
@@ -121,6 +118,153 @@ func buildContainerImage(spec *krknv1alpha1.KrknScenarioRunSpec, config *krknctl
 		config.QuayScenarioRegistry,
 		scenarioTag,
 	), nil
+}
+
+// buildJobLabels builds the common set of labels applied to all resources created
+// for a single cluster scenario job (ConfigMaps, Secrets, and the scenario Pod).
+// It always includes the krkn-job-id, krkn-scenario-run, krkn-scenario-name,
+// krkn-cluster-name, and krkn-target-request labels. When the scenario run has an
+// owner user set, the krkn.krkn-chaos.dev/owner-user label is added via getOwnerLabel.
+// Any entries in extra are merged in (used to add "app": "krkn-scenario" for the Pod).
+// This function performs no client I/O and is safe to unit test without a cluster.
+func buildJobLabels(jobID, clusterName string, scenarioRun *krknv1alpha1.KrknScenarioRun, extra map[string]string) map[string]string {
+	labels := map[string]string{
+		"krkn-job-id":         jobID,
+		"krkn-scenario-run":   scenarioRun.Name,
+		"krkn-scenario-name":  scenarioRun.Spec.ScenarioName,
+		"krkn-cluster-name":   clusterName,
+		"krkn-target-request": scenarioRun.Spec.TargetRequestID,
+	}
+	if ownerLabel := getOwnerLabel(scenarioRun); ownerLabel != "" {
+		labels["krkn.krkn-chaos.dev/owner-user"] = ownerLabel
+	}
+	for k, v := range extra {
+		labels[k] = v
+	}
+	return labels
+}
+
+// buildScenarioPod constructs the scenario Pod object for a single cluster job.
+// It is pure: it performs no client I/O. The caller is responsible for resolving
+// the kubeconfig ConfigMap name, the per-file ConfigMap names, the container image,
+// and the image pull secrets before invoking this builder, and for setting the
+// owner reference and creating the Pod afterwards. Keeping this construction
+// client-free makes the volume, mount, env, security context, and label logic
+// unit-testable without a live cluster.
+func buildScenarioPod(
+	jobID string,
+	clusterName string,
+	containerImage string,
+	kubeconfigConfigMapName string,
+	kubeconfigPath string,
+	fileConfigMaps []string,
+	imagePullSecrets []corev1.LocalObjectReference,
+	namespace string,
+	scenarioRun *krknv1alpha1.KrknScenarioRun,
+) *corev1.Pod {
+	// Build volumes and volume mounts
+	volumes := []corev1.Volume{
+		{
+			Name: "kubeconfig",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: kubeconfigConfigMapName,
+					},
+				},
+			},
+		},
+	}
+
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      "kubeconfig",
+			MountPath: kubeconfigPath,
+			SubPath:   "config",
+		},
+	}
+
+	// Add file mounts
+	for i, file := range scenarioRun.Spec.Files {
+		volumeName := fmt.Sprintf("file-%d", i)
+
+		volumes = append(volumes, corev1.Volume{
+			Name: volumeName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: fileConfigMaps[i],
+					},
+				},
+			},
+		})
+
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      volumeName,
+			MountPath: file.MountPath,
+			SubPath:   file.Name,
+		})
+	}
+
+	// Add writable tmp volume
+	volumes = append(volumes, corev1.Volume{
+		Name: "tmp",
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	})
+
+	volumeMounts = append(volumeMounts, corev1.VolumeMount{
+		Name:      "tmp",
+		MountPath: "/tmp",
+	})
+
+	// Convert environment map to EnvVar slice
+	envVars := make([]corev1.EnvVar, 0, len(scenarioRun.Spec.Environment))
+	for key, value := range scenarioRun.Spec.Environment {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  key,
+			Value: value,
+		})
+	}
+
+	// SecurityContext for running as krkn user (UID 1001)
+	var runAsUser int64 = 1001
+	var runAsGroup int64 = 1001
+	var fsGroup int64 = 1001
+
+	// Create the pod
+	podName := fmt.Sprintf("krkn-job-%s", jobID)
+	podLabels := buildJobLabels(jobID, clusterName, scenarioRun, map[string]string{
+		"app": "krkn-scenario",
+	})
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: namespace,
+			Labels:    podLabels,
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: "krkn-operator-krkn-scenario-runner",
+			RestartPolicy:      corev1.RestartPolicyNever,
+			ImagePullSecrets:   imagePullSecrets,
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsUser:  &runAsUser,
+				RunAsGroup: &runAsGroup,
+				FSGroup:    &fsGroup,
+			},
+			Containers: []corev1.Container{
+				{
+					Name:            "scenario",
+					Image:           containerImage,
+					Env:             envVars,
+					VolumeMounts:    volumeMounts,
+					ImagePullPolicy: corev1.PullAlways,
+				},
+			},
+			Volumes: volumes,
+		},
+	}
 }
 
 // Reconcile handles the reconciliation loop for KrknScenarioRun
@@ -344,16 +488,7 @@ func (r *KrknScenarioRunReconciler) prepareJobResources(
 
 	// Create ConfigMap for kubeconfig
 	kubeconfigConfigMapName := fmt.Sprintf("krkn-job-%s-kubeconfig", jobID)
-	kubeconfigLabels := map[string]string{
-		"krkn-job-id":         jobID,
-		"krkn-scenario-run":   scenarioRun.Name,
-		"krkn-scenario-name":  scenarioRun.Spec.ScenarioName,
-		"krkn-cluster-name":   clusterName,
-		"krkn-target-request": scenarioRun.Spec.TargetRequestID,
-	}
-	if ownerLabel := getOwnerLabel(scenarioRun); ownerLabel != "" {
-		kubeconfigLabels["krkn.krkn-chaos.dev/owner-user"] = ownerLabel
-	}
+	kubeconfigLabels := buildJobLabels(jobID, clusterName, scenarioRun, nil)
 	kubeconfigConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kubeconfigConfigMapName,
@@ -412,16 +547,7 @@ func (r *KrknScenarioRunReconciler) prepareJobResources(
 			return nil, fmt.Errorf("failed to decode file content for '%s': %w", file.Name, err)
 		}
 
-		fileLabels := map[string]string{
-			"krkn-job-id":         jobID,
-			"krkn-scenario-run":   scenarioRun.Name,
-			"krkn-scenario-name":  scenarioRun.Spec.ScenarioName,
-			"krkn-cluster-name":   clusterName,
-			"krkn-target-request": scenarioRun.Spec.TargetRequestID,
-		}
-		if ownerLabel := getOwnerLabel(scenarioRun); ownerLabel != "" {
-			fileLabels["krkn.krkn-chaos.dev/owner-user"] = ownerLabel
-		}
+		fileLabels := buildJobLabels(jobID, clusterName, scenarioRun, nil)
 		fileConfigMap := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      configMapName,
@@ -494,16 +620,7 @@ func (r *KrknScenarioRunReconciler) prepareJobResources(
 
 		dockerConfigJSON, _ := json.Marshal(dockerConfig)
 
-		secretLabels := map[string]string{
-			"krkn-job-id":         jobID,
-			"krkn-scenario-run":   scenarioRun.Name,
-			"krkn-scenario-name":  scenarioRun.Spec.ScenarioName,
-			"krkn-cluster-name":   clusterName,
-			"krkn-target-request": scenarioRun.Spec.TargetRequestID,
-		}
-		if ownerLabel := getOwnerLabel(scenarioRun); ownerLabel != "" {
-			secretLabels["krkn.krkn-chaos.dev/owner-user"] = ownerLabel
-		}
+		secretLabels := buildJobLabels(jobID, clusterName, scenarioRun, nil)
 		imagePullSecret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      imagePullSecretName,
@@ -533,91 +650,20 @@ func (r *KrknScenarioRunReconciler) prepareJobResources(
 		})
 	}
 
-	// Build volumes and volume mounts
-	volumes := []corev1.Volume{
-		{
-			Name: "kubeconfig",
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: kubeconfigConfigMapName,
-					},
-				},
-			},
-		},
-	}
-
-	volumeMounts := []corev1.VolumeMount{
-		{
-			Name:      "kubeconfig",
-			MountPath: kubeconfigPath,
-			SubPath:   "config",
-		},
-	}
-
-	// Add file mounts
-	// Skip first ConfigMap (kubeconfig), file ConfigMaps start from index 1
-	fileConfigMaps := createdConfigMaps[1:]
-	for i, file := range scenarioRun.Spec.Files {
-		volumeName := fmt.Sprintf("file-%d", i)
-
-		volumes = append(volumes, corev1.Volume{
-			Name: volumeName,
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: fileConfigMaps[i],
-					},
-				},
-			},
-		})
-
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      volumeName,
-			MountPath: file.MountPath,
-			SubPath:   file.Name,
-		})
-	}
-
-	// Add writable tmp volume
-	volumes = append(volumes, corev1.Volume{
-		Name: "tmp",
-		VolumeSource: corev1.VolumeSource{
-			EmptyDir: &corev1.EmptyDirVolumeSource{},
-		},
-	})
-
-	volumeMounts = append(volumeMounts, corev1.VolumeMount{
-		Name:      "tmp",
-		MountPath: "/tmp",
-	})
-
-	// Convert environment map to EnvVar slice
-	envVars := make([]corev1.EnvVar, 0, len(scenarioRun.Spec.Environment))
-	for key, value := range scenarioRun.Spec.Environment {
-		envVars = append(envVars, corev1.EnvVar{
-			Name:  key,
-			Value: value,
-		})
-	}
-
 	return &preparedJobResources{
 		jobID:             jobID,
 		clusterName:       clusterName,
 		clusterAPIURL:     clusterAPIURL,
 		containerImage:    containerImage,
 		kubeconfigPath:    kubeconfigPath,
-		volumes:           volumes,
-		volumeMounts:      volumeMounts,
-		envVars:           envVars,
 		imagePullSecrets:  imagePullSecrets,
 		createdConfigMaps: createdConfigMaps,
 		createdSecrets:    createdSecrets,
 	}, nil
 }
 
-// cleanupPreparedResources deletes ConfigMaps and Secrets created during resource preparation.
-// This is called when executeScenarioPod fails to prevent resource leaks.
+// cleanupPreparedResources deletes ConfigMaps and Secrets created during resource
+// preparation. It is called when executeScenarioPod fails to prevent resource leaks.
 func (r *KrknScenarioRunReconciler) cleanupPreparedResources(ctx context.Context, resources *preparedJobResources) {
 	logger := log.FromContext(ctx)
 
@@ -627,11 +673,9 @@ func (r *KrknScenarioRunReconciler) cleanupPreparedResources(ctx context.Context
 				Name:      cmName,
 				Namespace: r.Namespace,
 			},
-		}); err != nil {
-			if !apierrors.IsNotFound(err) {
-				logger.Error(err, "failed to delete ConfigMap during cleanup",
-					"configMapName", cmName, "jobID", resources.jobID)
-			}
+		}); err != nil && !apierrors.IsNotFound(err) {
+			logger.Error(err, "failed to delete ConfigMap during cleanup",
+				"configMapName", cmName, "jobID", resources.jobID)
 		}
 	}
 
@@ -641,17 +685,16 @@ func (r *KrknScenarioRunReconciler) cleanupPreparedResources(ctx context.Context
 				Name:      secretName,
 				Namespace: r.Namespace,
 			},
-		}); err != nil {
-			if !apierrors.IsNotFound(err) {
-				logger.Error(err, "failed to delete Secret during cleanup",
-					"secretName", secretName, "jobID", resources.jobID)
-			}
+		}); err != nil && !apierrors.IsNotFound(err) {
+			logger.Error(err, "failed to delete Secret during cleanup",
+				"secretName", secretName, "jobID", resources.jobID)
 		}
 	}
 }
 
-// executeScenarioPod creates the scenario pod using prepared resources and updates the scenario run status.
-// Takes the container image as a parameter to avoid reconstruction logic.
+// executeScenarioPod builds and creates the scenario Pod from prepared resources and
+// updates the scenario run status. On pod creation failure it cleans up the prepared
+// ConfigMaps and Secrets to avoid leaks.
 func (r *KrknScenarioRunReconciler) executeScenarioPod(
 	ctx context.Context,
 	scenarioRun *krknv1alpha1.KrknScenarioRun,
@@ -661,62 +704,30 @@ func (r *KrknScenarioRunReconciler) executeScenarioPod(
 ) error {
 	logger := log.FromContext(ctx)
 
-	// SecurityContext for running as krkn user (UID 1001)
-	var runAsUser int64 = 1001
-	var runAsGroup int64 = 1001
-	var fsGroup int64 = 1001
+	// The kubeconfig ConfigMap is always the first created; the rest are per-file mounts.
+	kubeconfigConfigMapName := resources.createdConfigMaps[0]
+	fileConfigMaps := resources.createdConfigMaps[1:]
 
-	// Create the pod
 	podName := fmt.Sprintf("krkn-job-%s", resources.jobID)
-	podLabels := map[string]string{
-		"app":                 "krkn-scenario",
-		"krkn-job-id":         resources.jobID,
-		"krkn-scenario-run":   scenarioRun.Name,
-		"krkn-scenario-name":  scenarioRun.Spec.ScenarioName,
-		"krkn-cluster-name":   resources.clusterName,
-		"krkn-target-request": scenarioRun.Spec.TargetRequestID,
-	}
-	if ownerLabel := getOwnerLabel(scenarioRun); ownerLabel != "" {
-		podLabels["krkn.krkn-chaos.dev/owner-user"] = ownerLabel
-	}
-
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      podName,
-			Namespace: r.Namespace,
-			Labels:    podLabels,
-		},
-		Spec: corev1.PodSpec{
-			ServiceAccountName: "krkn-operator-krkn-scenario-runner",
-			RestartPolicy:      corev1.RestartPolicyNever,
-			ImagePullSecrets:   resources.imagePullSecrets,
-			SecurityContext: &corev1.PodSecurityContext{
-				RunAsUser:  &runAsUser,
-				RunAsGroup: &runAsGroup,
-				FSGroup:    &fsGroup,
-			},
-			Containers: []corev1.Container{
-				{
-					Name:            "scenario",
-					Image:           resources.containerImage,
-					Env:             resources.envVars,
-					VolumeMounts:    resources.volumeMounts,
-					ImagePullPolicy: corev1.PullAlways,
-				},
-			},
-			Volumes: resources.volumes,
-		},
-	}
+	pod := buildScenarioPod(
+		resources.jobID,
+		resources.clusterName,
+		resources.containerImage,
+		kubeconfigConfigMapName,
+		resources.kubeconfigPath,
+		fileConfigMaps,
+		resources.imagePullSecrets,
+		r.Namespace,
+		scenarioRun,
+	)
 
 	// Set owner reference
 	if err := controllerutil.SetControllerReference(scenarioRun, pod, r.Scheme); err != nil {
-		// Cleanup resources on failure
 		r.cleanupPreparedResources(ctx, resources)
 		return fmt.Errorf("failed to set owner reference on pod: %w", err)
 	}
 
 	if err := r.Create(ctx, pod); err != nil {
-		// Cleanup resources on failure
 		r.cleanupPreparedResources(ctx, resources)
 		return fmt.Errorf("failed to create pod: %w", err)
 	}

--- a/internal/controller/krknscenariorun_controller_podspec_test.go
+++ b/internal/controller/krknscenariorun_controller_podspec_test.go
@@ -1,0 +1,311 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	krknv1alpha1 "github.com/krkn-chaos/krkn-operator/api/v1alpha1"
+)
+
+func TestBuildJobLabels(t *testing.T) {
+	tests := []struct {
+		name        string
+		jobID       string
+		clusterName string
+		scenarioRun *krknv1alpha1.KrknScenarioRun
+		extra       map[string]string
+		expected    map[string]string
+	}{
+		{
+			name:        "base labels without owner or extra",
+			jobID:       "job-123",
+			clusterName: "cluster-a",
+			scenarioRun: &krknv1alpha1.KrknScenarioRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "run-1"},
+				Spec: krknv1alpha1.KrknScenarioRunSpec{
+					ScenarioName:    "node-cpu-hog",
+					TargetRequestID: "tr-1",
+				},
+			},
+			extra: nil,
+			expected: map[string]string{
+				"krkn-job-id":         "job-123",
+				"krkn-scenario-run":   "run-1",
+				"krkn-scenario-name":  "node-cpu-hog",
+				"krkn-cluster-name":   "cluster-a",
+				"krkn-target-request": "tr-1",
+			},
+		},
+		{
+			name:        "with owner label",
+			jobID:       "job-456",
+			clusterName: "cluster-b",
+			scenarioRun: &krknv1alpha1.KrknScenarioRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "run-2"},
+				Spec: krknv1alpha1.KrknScenarioRunSpec{
+					ScenarioName:    "pod-scenarios",
+					TargetRequestID: "tr-2",
+					OwnerUserID:     "User.Name@Example.COM",
+				},
+			},
+			extra: nil,
+			expected: map[string]string{
+				"krkn-job-id":                    "job-456",
+				"krkn-scenario-run":              "run-2",
+				"krkn-scenario-name":             "pod-scenarios",
+				"krkn-cluster-name":              "cluster-b",
+				"krkn-target-request":            "tr-2",
+				"krkn.krkn-chaos.dev/owner-user": "user-name-example-com",
+			},
+		},
+		{
+			name:        "with extra app label (pod case)",
+			jobID:       "job-789",
+			clusterName: "cluster-c",
+			scenarioRun: &krknv1alpha1.KrknScenarioRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "run-3"},
+				Spec: krknv1alpha1.KrknScenarioRunSpec{
+					ScenarioName:    "zone-outage",
+					TargetRequestID: "tr-3",
+				},
+			},
+			extra: map[string]string{"app": "krkn-scenario"},
+			expected: map[string]string{
+				"app":                 "krkn-scenario",
+				"krkn-job-id":         "job-789",
+				"krkn-scenario-run":   "run-3",
+				"krkn-scenario-name":  "zone-outage",
+				"krkn-cluster-name":   "cluster-c",
+				"krkn-target-request": "tr-3",
+			},
+		},
+		{
+			name:        "with owner and extra app label",
+			jobID:       "job-999",
+			clusterName: "cluster-d",
+			scenarioRun: &krknv1alpha1.KrknScenarioRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "run-4"},
+				Spec: krknv1alpha1.KrknScenarioRunSpec{
+					ScenarioName:    "container-scenarios",
+					TargetRequestID: "tr-4",
+					OwnerUserID:     "owner@krkn.dev",
+				},
+			},
+			extra: map[string]string{"app": "krkn-scenario"},
+			expected: map[string]string{
+				"app":                            "krkn-scenario",
+				"krkn-job-id":                    "job-999",
+				"krkn-scenario-run":              "run-4",
+				"krkn-scenario-name":             "container-scenarios",
+				"krkn-cluster-name":              "cluster-d",
+				"krkn-target-request":            "tr-4",
+				"krkn.krkn-chaos.dev/owner-user": "owner-krkn-dev",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildJobLabels(tc.jobID, tc.clusterName, tc.scenarioRun, tc.extra)
+
+			if len(got) != len(tc.expected) {
+				t.Fatalf("expected %d labels, got %d: %v", len(tc.expected), len(got), got)
+			}
+			for k, want := range tc.expected {
+				if got[k] != want {
+					t.Errorf("label %q: expected %q, got %q", k, want, got[k])
+				}
+			}
+		})
+	}
+}
+
+func TestBuildScenarioPod(t *testing.T) {
+	scenarioRun := &krknv1alpha1.KrknScenarioRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-run"},
+		Spec: krknv1alpha1.KrknScenarioRunSpec{
+			ScenarioName:    "node-cpu-hog",
+			TargetRequestID: "tr-42",
+			OwnerUserID:     "someone@example.com",
+			Environment: map[string]string{
+				"CHAOS_DURATION": "60",
+			},
+			Files: []krknv1alpha1.FileMount{
+				{
+					Name:      "config.yaml",
+					Content:   "",
+					MountPath: "/opt/config.yaml",
+				},
+			},
+		},
+	}
+
+	imagePullSecrets := []corev1.LocalObjectReference{
+		{Name: "krkn-job-abc-registry"},
+	}
+
+	pod := buildScenarioPod(
+		"abc",
+		"cluster-x",
+		"quay.io/krkn-chaos/krkn-hub:node-cpu-hog",
+		"krkn-job-abc-kubeconfig",
+		"/home/krkn/.kube/config",
+		[]string{"krkn-job-abc-file-config-yaml"},
+		imagePullSecrets,
+		"krkn-operator-system",
+		scenarioRun,
+	)
+
+	// Pod name and namespace
+	if pod.Name != "krkn-job-abc" {
+		t.Errorf("expected pod name 'krkn-job-abc', got %q", pod.Name)
+	}
+	if pod.Namespace != "krkn-operator-system" {
+		t.Errorf("expected namespace 'krkn-operator-system', got %q", pod.Namespace)
+	}
+
+	// Labels: base set + app + owner
+	wantLabels := map[string]string{
+		"app":                            "krkn-scenario",
+		"krkn-job-id":                    "abc",
+		"krkn-scenario-run":              "my-run",
+		"krkn-scenario-name":             "node-cpu-hog",
+		"krkn-cluster-name":              "cluster-x",
+		"krkn-target-request":            "tr-42",
+		"krkn.krkn-chaos.dev/owner-user": "someone-example-com",
+	}
+	if len(pod.Labels) != len(wantLabels) {
+		t.Errorf("expected %d labels, got %d: %v", len(wantLabels), len(pod.Labels), pod.Labels)
+	}
+	for k, want := range wantLabels {
+		if pod.Labels[k] != want {
+			t.Errorf("pod label %q: expected %q, got %q", k, want, pod.Labels[k])
+		}
+	}
+
+	// Container: image, name, pull policy
+	if len(pod.Spec.Containers) != 1 {
+		t.Fatalf("expected 1 container, got %d", len(pod.Spec.Containers))
+	}
+	container := pod.Spec.Containers[0]
+	if container.Name != "scenario" {
+		t.Errorf("expected container name 'scenario', got %q", container.Name)
+	}
+	if container.Image != "quay.io/krkn-chaos/krkn-hub:node-cpu-hog" {
+		t.Errorf("unexpected container image: %q", container.Image)
+	}
+	if container.ImagePullPolicy != corev1.PullAlways {
+		t.Errorf("expected ImagePullPolicy PullAlways, got %q", container.ImagePullPolicy)
+	}
+
+	// Env presence
+	foundEnv := false
+	for _, e := range container.Env {
+		if e.Name == "CHAOS_DURATION" && e.Value == "60" {
+			foundEnv = true
+		}
+	}
+	if !foundEnv {
+		t.Errorf("expected env CHAOS_DURATION=60 to be present, got %v", container.Env)
+	}
+
+	// Restart policy
+	if pod.Spec.RestartPolicy != corev1.RestartPolicyNever {
+		t.Errorf("expected RestartPolicyNever, got %q", pod.Spec.RestartPolicy)
+	}
+
+	// ServiceAccount
+	if pod.Spec.ServiceAccountName != "krkn-operator-krkn-scenario-runner" {
+		t.Errorf("unexpected service account: %q", pod.Spec.ServiceAccountName)
+	}
+
+	// ImagePullSecrets passed through
+	if len(pod.Spec.ImagePullSecrets) != 1 || pod.Spec.ImagePullSecrets[0].Name != "krkn-job-abc-registry" {
+		t.Errorf("unexpected imagePullSecrets: %v", pod.Spec.ImagePullSecrets)
+	}
+
+	// SecurityContext UID/GID/FSGroup = 1001
+	sc := pod.Spec.SecurityContext
+	if sc == nil {
+		t.Fatal("expected pod SecurityContext to be set")
+	}
+	if sc.RunAsUser == nil || *sc.RunAsUser != 1001 {
+		t.Errorf("expected RunAsUser 1001, got %v", sc.RunAsUser)
+	}
+	if sc.RunAsGroup == nil || *sc.RunAsGroup != 1001 {
+		t.Errorf("expected RunAsGroup 1001, got %v", sc.RunAsGroup)
+	}
+	if sc.FSGroup == nil || *sc.FSGroup != 1001 {
+		t.Errorf("expected FSGroup 1001, got %v", sc.FSGroup)
+	}
+
+	// Volumes: kubeconfig, file-0, tmp
+	wantVolumes := map[string]bool{"kubeconfig": false, "file-0": false, "tmp": false}
+	for _, v := range pod.Spec.Volumes {
+		if _, ok := wantVolumes[v.Name]; ok {
+			wantVolumes[v.Name] = true
+		}
+	}
+	for name, found := range wantVolumes {
+		if !found {
+			t.Errorf("expected volume %q to be present, volumes: %v", name, pod.Spec.Volumes)
+		}
+	}
+	// kubeconfig volume references the resolved ConfigMap name
+	for _, v := range pod.Spec.Volumes {
+		if v.Name == "kubeconfig" {
+			if v.ConfigMap == nil || v.ConfigMap.Name != "krkn-job-abc-kubeconfig" {
+				t.Errorf("kubeconfig volume should reference 'krkn-job-abc-kubeconfig', got %v", v.ConfigMap)
+			}
+		}
+		if v.Name == "file-0" {
+			if v.ConfigMap == nil || v.ConfigMap.Name != "krkn-job-abc-file-config-yaml" {
+				t.Errorf("file-0 volume should reference 'krkn-job-abc-file-config-yaml', got %v", v.ConfigMap)
+			}
+		}
+	}
+
+	// VolumeMounts: kubeconfig (with mount path + subpath), file-0, tmp
+	wantMounts := map[string]bool{"kubeconfig": false, "file-0": false, "tmp": false}
+	for _, m := range container.VolumeMounts {
+		if _, ok := wantMounts[m.Name]; ok {
+			wantMounts[m.Name] = true
+		}
+		if m.Name == "kubeconfig" {
+			if m.MountPath != "/home/krkn/.kube/config" || m.SubPath != "config" {
+				t.Errorf("unexpected kubeconfig mount: %+v", m)
+			}
+		}
+		if m.Name == "tmp" && m.MountPath != "/tmp" {
+			t.Errorf("expected tmp mount path '/tmp', got %q", m.MountPath)
+		}
+		if m.Name == "file-0" {
+			if m.MountPath != "/opt/config.yaml" || m.SubPath != "config.yaml" {
+				t.Errorf("unexpected file-0 mount: %+v", m)
+			}
+		}
+	}
+	for name, found := range wantMounts {
+		if !found {
+			t.Errorf("expected volume mount %q to be present, mounts: %v", name, container.VolumeMounts)
+		}
+	}
+}


### PR DESCRIPTION
### Why I did this
I wanted the pod-building logic under test and couldn't get at it. It's welded to the `Get`/`Create` calls inside `createClusterJob`, so testing "did the pod come out with the right image/labels/volumes" meant spinning up a real cluster. On top of that the label map was copy-pasted four times in that same method, which got under my skin every time I read through it.

Closes #24 

### What I changed
- Added `buildJobLabels(jobID, clusterName, scenarioRun, extra)`: the common label set plus the owner label, with an `extra` map merged in. It replaces all four inline label maps. The pod passes `{"app": "krkn-scenario"}` as `extra`, the pull secret passes `nil`. Output is the same at every call site.
- Added `buildScenarioPod(...)`: builds and returns the `*corev1.Pod` from already-resolved inputs (image, kubeconfig/file ConfigMap names, pull secrets, namespace). No client calls inside it. `createClusterJob` still does all the `Get`/`Create` and the owner-reference wiring, it just hands the resolved values in.
- Added `krknscenariorun_controller_podspec_test.go` with table tests for both, no envtest.