### PR TITLE
feat(helm): add cluster proxy support for ACM deployment

### DIFF
--- a/charts/krkn-operator/templates/acm/deployment.yaml
+++ b/charts/krkn-operator/templates/acm/deployment.yaml
@@ -55,13 +55,15 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- with .Values.acm.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        # SERVICE_ACCOUNT_NAME must come AFTER extraEnv to prevent user override footgun
+        # If placed before extraEnv, a duplicate entry in extraEnv would silently win
         - name: SERVICE_ACCOUNT_NAME
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        {{- with .Values.acm.extraEnv }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
         resources:
           {{- toYaml .Values.acm.resources | nindent 10 }}
         livenessProbe:

--- a/charts/krkn-operator/templates/acm/deployment.yaml
+++ b/charts/krkn-operator/templates/acm/deployment.yaml
@@ -55,6 +55,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: SERVICE_ACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         {{- with .Values.acm.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/krkn-operator/templates/acm/deployment.yaml
+++ b/charts/krkn-operator/templates/acm/deployment.yaml
@@ -55,6 +55,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- with .Values.acm.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        # SERVICE_ACCOUNT_NAME must come AFTER extraEnv to prevent user override footgun
+        # If placed before extraEnv, a duplicate entry in extraEnv would silently win
         - name: SERVICE_ACCOUNT_NAME
           valueFrom:
             fieldRef:

--- a/charts/krkn-operator/templates/acm/rbac.yaml
+++ b/charts/krkn-operator/templates/acm/rbac.yaml
@@ -50,6 +50,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+- apiGroups:
   - proxy.open-cluster-management.io
   resources:
   - managedproxyconfigurations
@@ -68,13 +75,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - get
-  - list
 - apiGroups:
   - krkn.krkn-chaos.dev
   resources:

--- a/charts/krkn-operator/templates/acm/rbac.yaml
+++ b/charts/krkn-operator/templates/acm/rbac.yaml
@@ -56,6 +56,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - proxy.open-cluster-management.io
   resources:


### PR DESCRIPTION
## Summary

Adds complete cluster proxy support for krkn-operator-acm deployment, enabling optional connection to managed clusters through ACM/OCM cluster-proxy-addon instead of direct API server access.

## Changes

### 1. RBAC Permissions (`rbac.yaml`)
Added required permissions for cluster proxy mode:
- **Services** (core API): `get`, `list`, `watch` - discover cluster-proxy-addon-user service
- **ManagedProxyConfiguration** (proxy.open-cluster-management.io): `get`, `list`, `watch` - get proxy server configuration
- **ManifestWork** (work.open-cluster-management.io): `create`, `get`, `list`, `patch`, `update`, `watch` - deploy proxy RBAC to managed clusters automatically

### 2. Service Account Injection (`deployment.yaml`)
Added `SERVICE_ACCOUNT_NAME` environment variable to ACM deployment, populated from `spec.serviceAccountName`.

**Problem solved:**
The operator's `getServiceAccountName()` function reads `SERVICE_ACCOUNT_NAME` to determine which service account to use when creating ManifestWork for proxy RBAC. Without this env var, it defaulted to "controller-manager", but the actual service account is "krkn-operator-acm".

This caused a mismatch where ManifestWork granted cluster-admin to the wrong service account, resulting in Forbidden errors when using cluster terminal with proxy mode.

## Impact

- **Proxy mode**: Now works correctly with proper RBAC and service account configuration
- **Direct mode**: Unchanged, continues to work as before (default behavior)
- **Backward compatibility**: Fully maintained - these changes only enable optional proxy mode

## Testing

- [ ] Helm chart validation
- [ ] Deployment with proxy mode enabled
- [ ] Cluster terminal access verification
- [ ] Direct connection mode still works

## Related

- Part of cluster proxy support implementation for krkn-operator-acm
- Requires corresponding changes in krkn-operator-acm codebase