### PR TITLE
feat(files): add duplicate name detection and filePurpose categorization

### DIFF
--- a/internal/api/docs/docs.go
+++ b/internal/api/docs/docs.go
@@ -230,7 +230,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Filter by file purpose (e.g., workflow-template)",
+                        "description": "Filter by file purpose (file, workflow-template, resiliency-score)",
                         "name": "filePurpose",
                         "in": "query"
                     }
@@ -309,6 +309,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/internal_api.ErrorResponse"
                         }
                     },
+                    "409": {
+                        "description": "File name already exists",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
@@ -336,7 +342,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Filter by file purpose (e.g., workflow-template)",
+                        "description": "Filter by file purpose (file, workflow-template, resiliency-score)",
                         "name": "filePurpose",
                         "in": "query"
                     }
@@ -1469,6 +1475,12 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Workflow name already exists",
                         "schema": {
                             "$ref": "#/definitions/internal_api.ErrorResponse"
                         }

--- a/internal/api/docs/swagger.json
+++ b/internal/api/docs/swagger.json
@@ -224,7 +224,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Filter by file purpose (e.g., workflow-template)",
+                        "description": "Filter by file purpose (file, workflow-template, resiliency-score)",
                         "name": "filePurpose",
                         "in": "query"
                     }
@@ -303,6 +303,12 @@
                             "$ref": "#/definitions/internal_api.ErrorResponse"
                         }
                     },
+                    "409": {
+                        "description": "File name already exists",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
@@ -330,7 +336,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Filter by file purpose (e.g., workflow-template)",
+                        "description": "Filter by file purpose (file, workflow-template, resiliency-score)",
                         "name": "filePurpose",
                         "in": "query"
                     }
@@ -1463,6 +1469,12 @@
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Workflow name already exists",
                         "schema": {
                             "$ref": "#/definitions/internal_api.ErrorResponse"
                         }

--- a/internal/api/docs/swagger.yaml
+++ b/internal/api/docs/swagger.yaml
@@ -784,7 +784,7 @@ paths:
       description: Get list of all file ConfigMaps (admin only). Supports filtering
         by filePurpose query parameter.
       parameters:
-      - description: Filter by file purpose (e.g., workflow-template)
+      - description: Filter by file purpose (file, workflow-template, resiliency-score)
         in: query
         name: filePurpose
         type: string
@@ -840,6 +840,10 @@ paths:
           description: Unauthorized
           schema:
             $ref: '#/definitions/internal_api.ErrorResponse'
+        "409":
+          description: File name already exists
+          schema:
+            $ref: '#/definitions/internal_api.ErrorResponse'
         "500":
           description: Internal server error
           schema:
@@ -854,7 +858,7 @@ paths:
       description: Get files accessible to current user (own files, group files, public
         files). Supports filtering by filePurpose query parameter.
       parameters:
-      - description: Filter by file purpose (e.g., workflow-template)
+      - description: Filter by file purpose (file, workflow-template, resiliency-score)
         in: query
         name: filePurpose
         type: string
@@ -1682,6 +1686,10 @@ paths:
             $ref: '#/definitions/internal_api.ErrorResponse'
         "401":
           description: Unauthorized
+          schema:
+            $ref: '#/definitions/internal_api.ErrorResponse'
+        "409":
+          description: Workflow name already exists
           schema:
             $ref: '#/definitions/internal_api.ErrorResponse'
         "500":

--- a/internal/api/files_handlers.go
+++ b/internal/api/files_handlers.go
@@ -48,6 +48,7 @@ import (
 // @Success 201 {object} files.CreateFileResponse "File created"
 // @Failure 400 {object} ErrorResponse "Invalid request or validation error"
 // @Failure 401 {object} ErrorResponse "Unauthorized"
+// @Failure 409 {object} ErrorResponse "File name already exists"
 // @Failure 500 {object} ErrorResponse "Internal server error"
 // @Router /files [post]
 func (h *Handler) CreateFile(w http.ResponseWriter, r *http.Request) {
@@ -90,11 +91,44 @@ func (h *Handler) CreateFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Default filePurpose to "file" if not specified
+	if req.FilePurpose == "" {
+		req.FilePurpose = files.FilePurposeFile
+	}
+
 	// Validate filePurpose - only workflow API can create workflow-template files
-	if req.FilePurpose == "workflow-template" {
+	if req.FilePurpose == files.FilePurposeWorkflow {
 		writeJSONError(w, http.StatusBadRequest, ErrorResponse{
 			Error:   "bad_request",
 			Message: "Use POST /api/v1/workflows to create workflow templates",
+		})
+		return
+	}
+
+	// Validate filePurpose is a known value
+	if !files.IsValidFilePurpose(req.FilePurpose) {
+		writeJSONError(w, http.StatusBadRequest, ErrorResponse{
+			Error:   "bad_request",
+			Message: fmt.Sprintf("Invalid filePurpose '%s'. Valid values: %s", req.FilePurpose, strings.Join(files.ValidFilePurposes(), ", ")),
+		})
+		return
+	}
+
+	// Check for duplicate logical name (global uniqueness)
+	logicalName := deriveLogicalName(req.FileName, req.WorkflowName)
+	existingID, err := h.checkDuplicateLogicalName(ctx, logicalName, "")
+	if err != nil {
+		logger.Error(err, "Failed to check for duplicate file name", "logicalName", logicalName)
+		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
+			Error:   "internal_error",
+			Message: "Failed to validate file name uniqueness",
+		})
+		return
+	}
+	if existingID != "" {
+		writeJSONError(w, http.StatusConflict, ErrorResponse{
+			Error:   "conflict",
+			Message: fmt.Sprintf("A file with name '%s' already exists (ID: %s)", logicalName, existingID),
 		})
 		return
 	}
@@ -161,7 +195,7 @@ func (h *Handler) CreateFile(w http.ResponseWriter, r *http.Request) {
 // @Tags files
 // @Produce json
 // @Security BearerAuth
-// @Param filePurpose query string false "Filter by file purpose (e.g., workflow-template)"
+// @Param filePurpose query string false "Filter by file purpose (file, workflow-template, resiliency-score)"
 // @Success 200 {object} files.ListFilesResponse "List of files"
 // @Failure 401 {object} ErrorResponse "Unauthorized"
 // @Failure 403 {object} ErrorResponse "Forbidden (admin only)"
@@ -371,6 +405,29 @@ func (h *Handler) UpdateFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Check for duplicate logical name on rename (exclude current file)
+	workflowName := ""
+	if req.WorkflowName != nil {
+		workflowName = *req.WorkflowName
+	}
+	logicalName := deriveLogicalName(req.FileName, workflowName)
+	existingID, err := h.checkDuplicateLogicalName(ctx, logicalName, fileID)
+	if err != nil {
+		logger.Error(err, "Failed to check for duplicate file name", "logicalName", logicalName)
+		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
+			Error:   "internal_error",
+			Message: "Failed to validate file name uniqueness",
+		})
+		return
+	}
+	if existingID != "" {
+		writeJSONError(w, http.StatusConflict, ErrorResponse{
+			Error:   "conflict",
+			Message: fmt.Sprintf("A file with name '%s' already exists (ID: %s)", logicalName, existingID),
+		})
+		return
+	}
+
 	// Get current user for audit trail
 	updatedBy := claims.UserID
 
@@ -491,7 +548,7 @@ func (h *Handler) DeleteFile(w http.ResponseWriter, r *http.Request) {
 // @Tags files
 // @Produce json
 // @Security BearerAuth
-// @Param filePurpose query string false "Filter by file purpose (e.g., workflow-template)"
+// @Param filePurpose query string false "Filter by file purpose (file, workflow-template, resiliency-score)"
 // @Success 200 {object} files.AvailableFilesResponse "List of accessible files"
 // @Failure 401 {object} ErrorResponse "Unauthorized"
 // @Failure 500 {object} ErrorResponse "Internal server error"
@@ -774,7 +831,7 @@ func buildFileResponse(configMap *corev1.ConfigMap) files.FileResponse {
 
 	// Get workflow name with backwards-compatible fallback
 	workflowName := configMap.Annotations[files.WorkflowNameAnnotation]
-	if workflowName == "" && files.ExtractFilePurposeFromLabels(configMap.Labels) == "workflow-template" {
+	if workflowName == "" && files.ExtractFilePurposeFromLabels(configMap.Labels) == files.FilePurposeWorkflow {
 		// Fallback for workflows created before workflowName annotation was added
 		workflowName = fileName
 	}
@@ -817,6 +874,61 @@ func buildFileInfo(configMap *corev1.ConfigMap) files.FileInfo {
 		CreatedAt:   configMap.Annotations[files.CreatedAtAnnotation],
 		UpdatedAt:   configMap.Annotations[files.UpdatedAtAnnotation],
 	}
+}
+
+// extractLogicalName derives the logical name from an existing file ConfigMap.
+// For workflows, the logical name is the workflowName annotation.
+// For regular files, it is the primary Data key (excluding studioLayout.json).
+func extractLogicalName(cm *corev1.ConfigMap) string {
+	if wn := cm.Annotations[files.WorkflowNameAnnotation]; wn != "" {
+		return wn
+	}
+	for k := range cm.Data {
+		if k != "studioLayout.json" {
+			return k
+		}
+	}
+	return ""
+}
+
+// deriveLogicalName derives the logical name from request fields.
+// If workflowName is set, it takes precedence (workflow identity).
+// Otherwise, fileName is used (regular file identity).
+func deriveLogicalName(fileName, workflowName string) string {
+	if workflowName != "" {
+		return workflowName
+	}
+	return fileName
+}
+
+// checkDuplicateLogicalName checks if a file with the same logical name already exists.
+// The check is global across all filePurpose values.
+// excludeFileID can be set to skip a specific file (for update operations).
+// Returns the existing file's ID if a duplicate is found, or empty string if no conflict.
+func (h *Handler) checkDuplicateLogicalName(ctx context.Context, logicalName, excludeFileID string) (string, error) {
+	var configMapList corev1.ConfigMapList
+	err := h.client.List(ctx, &configMapList,
+		client.InNamespace(h.namespace),
+		client.MatchingLabels{
+			files.AppNameLabel:      files.AppName,
+			files.AppComponentLabel: files.ComponentFile,
+		},
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to list file ConfigMaps for duplicate check: %w", err)
+	}
+
+	for i := range configMapList.Items {
+		cm := &configMapList.Items[i]
+		existingID := files.ExtractFileIDFromLabels(cm.Labels)
+		if excludeFileID != "" && existingID == excludeFileID {
+			continue
+		}
+		if extractLogicalName(cm) == logicalName {
+			return existingID, nil
+		}
+	}
+	return "", nil
 }
 
 // validateCreateFileRequest validates a CreateFileRequest

--- a/internal/api/files_handlers.go
+++ b/internal/api/files_handlers.go
@@ -114,6 +114,11 @@ func (h *Handler) CreateFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Only workflow-template files can set workflowName
+	if req.FilePurpose != files.FilePurposeWorkflow {
+		req.WorkflowName = ""
+	}
+
 	// Check for duplicate logical name (global uniqueness)
 	logicalName := deriveLogicalName(req.FileName, req.WorkflowName)
 	existingID, err := h.checkDuplicateLogicalName(ctx, logicalName, "")
@@ -126,9 +131,10 @@ func (h *Handler) CreateFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if existingID != "" {
+		logger.Info("duplicate file name detected", "logicalName", logicalName, "existingID", existingID)
 		writeJSONError(w, http.StatusConflict, ErrorResponse{
 			Error:   "conflict",
-			Message: fmt.Sprintf("A file with name '%s' already exists (ID: %s)", logicalName, existingID),
+			Message: fmt.Sprintf("A file with name '%s' already exists", logicalName),
 		})
 		return
 	}
@@ -151,7 +157,7 @@ func (h *Handler) CreateFile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Build labels and annotations
-	labels := files.BuildFileLabels(fileID, req.FileType, req.Groups, req.AvailableToAll, req.FilePurpose)
+	labels := files.BuildFileLabels(fileID, req.FileType, req.Groups, req.AvailableToAll, req.FilePurpose, logicalName)
 	annotations := files.BuildFileAnnotations(
 		req.Description,
 		createdBy,
@@ -369,6 +375,15 @@ func (h *Handler) UpdateFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Block workflow-template reclassification via /files
+	if req.FilePurpose == files.FilePurposeWorkflow {
+		writeJSONError(w, http.StatusBadRequest, ErrorResponse{
+			Error:   "bad_request",
+			Message: "Use POST /api/v1/workflows to manage workflow templates",
+		})
+		return
+	}
+
 	// Load existing ConfigMap by file ID
 	configMap, err := h.loadFileConfigMapByID(ctx, fileID)
 	if err != nil {
@@ -385,6 +400,12 @@ func (h *Handler) UpdateFile(w http.ResponseWriter, r *http.Request) {
 			})
 		}
 		return
+	}
+
+	// Preserve existing filePurpose — /files cannot reclassify resources
+	existingPurpose := files.ExtractFilePurposeFromLabels(configMap.Labels)
+	if existingPurpose != "" {
+		req.FilePurpose = existingPurpose
 	}
 
 	// Check ownership - only owner or admin can update files
@@ -405,11 +426,13 @@ func (h *Handler) UpdateFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check for duplicate logical name on rename (exclude current file)
+	// Only workflow-template files can set workflowName
 	workflowName := ""
-	if req.WorkflowName != nil {
+	if req.FilePurpose == files.FilePurposeWorkflow && req.WorkflowName != nil {
 		workflowName = *req.WorkflowName
 	}
+
+	// Check for duplicate logical name on rename (exclude current file)
 	logicalName := deriveLogicalName(req.FileName, workflowName)
 	existingID, err := h.checkDuplicateLogicalName(ctx, logicalName, fileID)
 	if err != nil {
@@ -421,9 +444,10 @@ func (h *Handler) UpdateFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if existingID != "" {
+		logger.Info("duplicate file name detected on update", "logicalName", logicalName, "existingID", existingID)
 		writeJSONError(w, http.StatusConflict, ErrorResponse{
 			Error:   "conflict",
-			Message: fmt.Sprintf("A file with name '%s' already exists (ID: %s)", logicalName, existingID),
+			Message: fmt.Sprintf("A file with name '%s' already exists", logicalName),
 		})
 		return
 	}
@@ -440,7 +464,7 @@ func (h *Handler) UpdateFile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Update labels and annotations (preserve existing file ID)
-	configMap.Labels = files.BuildFileLabels(fileID, req.FileType, req.Groups, req.AvailableToAll, req.FilePurpose)
+	configMap.Labels = files.BuildFileLabels(fileID, req.FileType, req.Groups, req.AvailableToAll, req.FilePurpose, logicalName)
 	configMap.Annotations = files.UpdateFileAnnotations(
 		configMap.Annotations,
 		req.Description,
@@ -880,8 +904,10 @@ func buildFileInfo(configMap *corev1.ConfigMap) files.FileInfo {
 // For workflows, the logical name is the workflowName annotation.
 // For regular files, it is the primary Data key (excluding studioLayout.json).
 func extractLogicalName(cm *corev1.ConfigMap) string {
-	if wn := cm.Annotations[files.WorkflowNameAnnotation]; wn != "" {
-		return wn
+	if files.ExtractFilePurposeFromLabels(cm.Labels) == files.FilePurposeWorkflow {
+		if wn := cm.Annotations[files.WorkflowNameAnnotation]; wn != "" {
+			return wn
+		}
 	}
 	for k := range cm.Data {
 		if k != "studioLayout.json" {
@@ -902,7 +928,7 @@ func deriveLogicalName(fileName, workflowName string) string {
 }
 
 // checkDuplicateLogicalName checks if a file with the same logical name already exists.
-// The check is global across all filePurpose values.
+// Uses a label selector on the logical-name hash for efficient server-side filtering.
 // excludeFileID can be set to skip a specific file (for update operations).
 // Returns the existing file's ID if a duplicate is found, or empty string if no conflict.
 func (h *Handler) checkDuplicateLogicalName(ctx context.Context, logicalName, excludeFileID string) (string, error) {
@@ -910,14 +936,16 @@ func (h *Handler) checkDuplicateLogicalName(ctx context.Context, logicalName, ex
 	err := h.client.List(ctx, &configMapList,
 		client.InNamespace(h.namespace),
 		client.MatchingLabels{
-			files.AppNameLabel:      files.AppName,
-			files.AppComponentLabel: files.ComponentFile,
+			files.AppNameLabel:        files.AppName,
+			files.AppComponentLabel:   files.ComponentFile,
+			files.LogicalNameHashLabel: files.HashLogicalName(logicalName),
 		},
 	)
 	if err != nil {
 		return "", fmt.Errorf("failed to list file ConfigMaps for duplicate check: %w", err)
 	}
 
+	// Verify exact match (hash collisions are theoretically possible)
 	for i := range configMapList.Items {
 		cm := &configMapList.Items[i]
 		existingID := files.ExtractFileIDFromLabels(cm.Labels)

--- a/internal/api/files_handlers.go
+++ b/internal/api/files_handlers.go
@@ -114,9 +114,9 @@ func (h *Handler) CreateFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Only workflow-template files can set workflowName
+	// For non-workflow files, store fileName as the logical name in the same annotation
 	if req.FilePurpose != files.FilePurposeWorkflow {
-		req.WorkflowName = ""
+		req.WorkflowName = req.FileName
 	}
 
 	// Generate unique file ID (UUID)
@@ -424,8 +424,8 @@ func (h *Handler) UpdateFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Only workflow-template files can set workflowName
-	workflowName := ""
+	// Derive the logical name: workflowName for workflows, fileName for regular files
+	workflowName := req.FileName
 	if req.FilePurpose == files.FilePurposeWorkflow && req.WorkflowName != nil {
 		workflowName = *req.WorkflowName
 	}
@@ -469,7 +469,7 @@ func (h *Handler) UpdateFile(w http.ResponseWriter, r *http.Request) {
 		configMap.Annotations,
 		req.Description,
 		updatedBy,
-		req.WorkflowName,
+		&workflowName,
 	)
 
 	// Update data
@@ -860,33 +860,26 @@ func (h *Handler) isFileOwnerOrAdmin(ctx context.Context, configMap *corev1.Conf
 
 // buildFileResponse builds a FileResponse from a ConfigMap
 func buildFileResponse(configMap *corev1.ConfigMap) files.FileResponse {
-	// Extract file name, content, and studioLayout from data
-	// studioLayout.json is separate from the main file content
-	fileName := ""
+	// Extract content and studioLayout from data
 	content := ""
 	studioLayout := ""
 	for k, v := range configMap.Data {
-		if k == "studioLayout.json" {
+		switch k {
+		case "studioLayout.json":
 			studioLayout = v
-		} else {
-			fileName = k
+		default:
 			content = v
 		}
 	}
 
-	// Get workflow name with backwards-compatible fallback
-	workflowName := configMap.Annotations[files.WorkflowNameAnnotation]
-	if workflowName == "" && files.ExtractFilePurposeFromLabels(configMap.Labels) == files.FilePurposeWorkflow {
-		// Fallback for workflows created before workflowName annotation was added
-		workflowName = fileName
-	}
+	logicalName := configMap.Annotations[files.WorkflowNameAnnotation]
 
 	return files.FileResponse{
 		FileID:         files.ExtractFileIDFromLabels(configMap.Labels),
-		FileName:       fileName,
+		FileName:       logicalName,
 		Content:        content,
 		StudioLayout:   studioLayout,
-		WorkflowName:   workflowName,
+		WorkflowName:   logicalName,
 		Description:    configMap.Annotations[files.DescriptionAnnotation],
 		FileType:       files.ExtractFileTypeFromLabels(configMap.Labels),
 		FilePurpose:    files.ExtractFilePurposeFromLabels(configMap.Labels),
@@ -901,18 +894,9 @@ func buildFileResponse(configMap *corev1.ConfigMap) files.FileResponse {
 
 // buildFileInfo builds a FileInfo from a ConfigMap (minimal user-facing info)
 func buildFileInfo(configMap *corev1.ConfigMap) files.FileInfo {
-	// Extract primary file name from data (exclude studioLayout.json)
-	fileName := ""
-	for k := range configMap.Data {
-		if k != "studioLayout.json" {
-			fileName = k
-			break
-		}
-	}
-
 	return files.FileInfo{
 		FileID:      files.ExtractFileIDFromLabels(configMap.Labels),
-		FileName:    fileName,
+		FileName:    configMap.Annotations[files.WorkflowNameAnnotation],
 		Description: configMap.Annotations[files.DescriptionAnnotation],
 		FileType:    files.ExtractFileTypeFromLabels(configMap.Labels),
 		FilePurpose: files.ExtractFilePurposeFromLabels(configMap.Labels),
@@ -925,17 +909,7 @@ func buildFileInfo(configMap *corev1.ConfigMap) files.FileInfo {
 // For workflows, the logical name is the workflowName annotation.
 // For regular files, it is the primary Data key (excluding studioLayout.json).
 func extractLogicalName(cm *corev1.ConfigMap) string {
-	if files.ExtractFilePurposeFromLabels(cm.Labels) == files.FilePurposeWorkflow {
-		if wn := cm.Annotations[files.WorkflowNameAnnotation]; wn != "" {
-			return wn
-		}
-	}
-	for k := range cm.Data {
-		if k != "studioLayout.json" {
-			return k
-		}
-	}
-	return ""
+	return cm.Annotations[files.WorkflowNameAnnotation]
 }
 
 // deriveLogicalName derives the logical name from request fields.

--- a/internal/api/files_handlers.go
+++ b/internal/api/files_handlers.go
@@ -119,31 +119,26 @@ func (h *Handler) CreateFile(w http.ResponseWriter, r *http.Request) {
 		req.WorkflowName = ""
 	}
 
-	// Check for duplicate logical name (global uniqueness)
+	// Generate unique file ID (UUID)
+	fileID := uuid.New().String()
 	logicalName := deriveLogicalName(req.FileName, req.WorkflowName)
-	existingID, err := h.checkDuplicateLogicalName(ctx, logicalName, "")
-	if err != nil {
-		logger.Error(err, "Failed to check for duplicate file name", "logicalName", logicalName)
+
+	// Atomically reserve the logical name (prevents concurrent duplicates)
+	if err := h.reserveLogicalName(ctx, logicalName, fileID); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			writeJSONError(w, http.StatusConflict, ErrorResponse{
+				Error:   "conflict",
+				Message: fmt.Sprintf("A file with name '%s' already exists", logicalName),
+			})
+			return
+		}
+		logger.Error(err, "Failed to reserve logical name", "logicalName", logicalName)
 		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
 			Error:   "internal_error",
 			Message: "Failed to validate file name uniqueness",
 		})
 		return
 	}
-	if existingID != "" {
-		logger.Info("duplicate file name detected", "logicalName", logicalName, "existingID", existingID)
-		writeJSONError(w, http.StatusConflict, ErrorResponse{
-			Error:   "conflict",
-			Message: fmt.Sprintf("A file with name '%s' already exists", logicalName),
-		})
-		return
-	}
-
-	// Generate unique file ID (UUID)
-	fileID := uuid.New().String()
-
-	// Generate ConfigMap name from file ID
-	configMapName := fmt.Sprintf("file-%s", fileID)
 
 	// Get current user for audit trail
 	createdBy := claims.UserID
@@ -152,7 +147,6 @@ func (h *Handler) CreateFile(w http.ResponseWriter, r *http.Request) {
 	if req.FileType != "" {
 		if err := h.ensureFileTypeExists(ctx, req.FileType, createdBy); err != nil {
 			logger.Error(err, "Failed to ensure file type exists", "fileType", req.FileType)
-			// Continue anyway - file type is optional metadata
 		}
 	}
 
@@ -161,10 +155,10 @@ func (h *Handler) CreateFile(w http.ResponseWriter, r *http.Request) {
 	annotations := files.BuildFileAnnotations(
 		req.Description,
 		createdBy,
-		req.WorkflowName, // Empty for regular files, populated for workflows
+		req.WorkflowName,
 	)
 
-	// Create ConfigMap
+	configMapName := fmt.Sprintf("file-%s", fileID)
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        configMapName,
@@ -178,7 +172,11 @@ func (h *Handler) CreateFile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.client.Create(ctx, configMap); err != nil {
-		logger.Error(err, "Failed to create file ConfigMap", "fileID", fileID, "configMapName", configMapName)
+		logger.Error(err, "Failed to create file ConfigMap", "fileID", fileID)
+		// Rollback reservation
+		if releaseErr := h.releaseLogicalName(ctx, logicalName); releaseErr != nil {
+			logger.Error(releaseErr, "Failed to release reservation after file creation failure", "logicalName", logicalName)
+		}
 		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
 			Error:   "internal_error",
 			Message: "Failed to create file",
@@ -432,24 +430,27 @@ func (h *Handler) UpdateFile(w http.ResponseWriter, r *http.Request) {
 		workflowName = *req.WorkflowName
 	}
 
-	// Check for duplicate logical name on rename (exclude current file)
-	logicalName := deriveLogicalName(req.FileName, workflowName)
-	existingID, err := h.checkDuplicateLogicalName(ctx, logicalName, fileID)
-	if err != nil {
-		logger.Error(err, "Failed to check for duplicate file name", "logicalName", logicalName)
-		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
-			Error:   "internal_error",
-			Message: "Failed to validate file name uniqueness",
-		})
-		return
-	}
-	if existingID != "" {
-		logger.Info("duplicate file name detected on update", "logicalName", logicalName, "existingID", existingID)
-		writeJSONError(w, http.StatusConflict, ErrorResponse{
-			Error:   "conflict",
-			Message: fmt.Sprintf("A file with name '%s' already exists", logicalName),
-		})
-		return
+	newLogicalName := deriveLogicalName(req.FileName, workflowName)
+	oldLogicalName := extractLogicalName(configMap)
+	renamed := newLogicalName != oldLogicalName
+
+	// On rename, atomically reserve the new name
+	if renamed {
+		if err := h.reserveLogicalName(ctx, newLogicalName, fileID); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				writeJSONError(w, http.StatusConflict, ErrorResponse{
+					Error:   "conflict",
+					Message: fmt.Sprintf("A file with name '%s' already exists", newLogicalName),
+				})
+				return
+			}
+			logger.Error(err, "Failed to reserve new logical name", "logicalName", newLogicalName)
+			writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
+				Error:   "internal_error",
+				Message: "Failed to validate file name uniqueness",
+			})
+			return
+		}
 	}
 
 	// Get current user for audit trail
@@ -459,17 +460,16 @@ func (h *Handler) UpdateFile(w http.ResponseWriter, r *http.Request) {
 	if req.FileType != "" {
 		if err := h.ensureFileTypeExists(ctx, req.FileType, updatedBy); err != nil {
 			logger.Error(err, "Failed to ensure file type exists", "fileType", req.FileType)
-			// Continue anyway - file type is optional metadata
 		}
 	}
 
 	// Update labels and annotations (preserve existing file ID)
-	configMap.Labels = files.BuildFileLabels(fileID, req.FileType, req.Groups, req.AvailableToAll, req.FilePurpose, logicalName)
+	configMap.Labels = files.BuildFileLabels(fileID, req.FileType, req.Groups, req.AvailableToAll, req.FilePurpose, newLogicalName)
 	configMap.Annotations = files.UpdateFileAnnotations(
 		configMap.Annotations,
 		req.Description,
 		updatedBy,
-		req.WorkflowName, // Pointer: nil preserves existing, non-nil updates/deletes
+		req.WorkflowName,
 	)
 
 	// Update data
@@ -479,11 +479,24 @@ func (h *Handler) UpdateFile(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.client.Update(ctx, configMap); err != nil {
 		logger.Error(err, "Failed to update file", "fileID", fileID)
+		// Rollback new reservation on failure
+		if renamed {
+			if releaseErr := h.releaseLogicalName(ctx, newLogicalName); releaseErr != nil {
+				logger.Error(releaseErr, "Failed to release new reservation after update failure", "logicalName", newLogicalName)
+			}
+		}
 		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
 			Error:   "internal_error",
 			Message: "Failed to update file",
 		})
 		return
+	}
+
+	// Release old reservation on successful rename
+	if renamed && oldLogicalName != "" {
+		if err := h.releaseLogicalName(ctx, oldLogicalName); err != nil {
+			logger.Error(err, "Failed to release old name reservation", "logicalName", oldLogicalName)
+		}
 	}
 
 	logger.Info("Updated file", "fileID", fileID, "updatedBy", updatedBy)
@@ -556,6 +569,14 @@ func (h *Handler) DeleteFile(w http.ResponseWriter, r *http.Request) {
 			Message: "Failed to delete file",
 		})
 		return
+	}
+
+	// Release the logical name reservation
+	logicalName := extractLogicalName(configMap)
+	if logicalName != "" {
+		if err := h.releaseLogicalName(ctx, logicalName); err != nil {
+			logger.Error(err, "Failed to release name reservation", "logicalName", logicalName, "fileID", fileID)
+		}
 	}
 
 	logger.Info("Deleted file", "fileID", fileID)
@@ -927,36 +948,41 @@ func deriveLogicalName(fileName, workflowName string) string {
 	return fileName
 }
 
-// checkDuplicateLogicalName checks if a file with the same logical name already exists.
-// Uses a label selector on the logical-name hash for efficient server-side filtering.
-// excludeFileID can be set to skip a specific file (for update operations).
-// Returns the existing file's ID if a duplicate is found, or empty string if no conflict.
-func (h *Handler) checkDuplicateLogicalName(ctx context.Context, logicalName, excludeFileID string) (string, error) {
-	var configMapList corev1.ConfigMapList
-	err := h.client.List(ctx, &configMapList,
-		client.InNamespace(h.namespace),
-		client.MatchingLabels{
-			files.AppNameLabel:        files.AppName,
-			files.AppComponentLabel:   files.ComponentFile,
-			files.LogicalNameHashLabel: files.HashLogicalName(logicalName),
+// reserveLogicalName atomically reserves a logical name by creating a deterministic
+// ConfigMap. Kubernetes rejects the Create with AlreadyExists if the name is taken,
+// preventing concurrent requests from creating duplicates.
+func (h *Handler) reserveLogicalName(ctx context.Context, logicalName, fileID string) error {
+	reservation := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      files.ReservationName(logicalName),
+			Namespace: h.namespace,
+			Labels: map[string]string{
+				files.AppNameLabel:      files.AppName,
+				files.AppComponentLabel: files.ComponentFileReservation,
+			},
 		},
-	)
-	if err != nil {
-		return "", fmt.Errorf("failed to list file ConfigMaps for duplicate check: %w", err)
+		Data: map[string]string{
+			"logicalName": logicalName,
+			"fileID":      fileID,
+		},
 	}
+	return h.client.Create(ctx, reservation)
+}
 
-	// Verify exact match (hash collisions are theoretically possible)
-	for i := range configMapList.Items {
-		cm := &configMapList.Items[i]
-		existingID := files.ExtractFileIDFromLabels(cm.Labels)
-		if excludeFileID != "" && existingID == excludeFileID {
-			continue
-		}
-		if extractLogicalName(cm) == logicalName {
-			return existingID, nil
-		}
+// releaseLogicalName deletes the reservation ConfigMap for a logical name.
+// Ignores NotFound errors (idempotent).
+func (h *Handler) releaseLogicalName(ctx context.Context, logicalName string) error {
+	reservation := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      files.ReservationName(logicalName),
+			Namespace: h.namespace,
+		},
 	}
-	return "", nil
+	err := h.client.Delete(ctx, reservation)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
 }
 
 // validateCreateFileRequest validates a CreateFileRequest

--- a/internal/api/files_handlers.go
+++ b/internal/api/files_handlers.go
@@ -424,13 +424,23 @@ func (h *Handler) UpdateFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Derive the logical name: workflowName for workflows, fileName for regular files
-	workflowName := req.FileName
-	if req.FilePurpose == files.FilePurposeWorkflow && req.WorkflowName != nil {
-		workflowName = *req.WorkflowName
+	// Derive the logical name and annotation pointer.
+	// For workflows: nil req.WorkflowName means preserve existing (pointer semantics).
+	// For regular files: always sync annotation to fileName.
+	var workflowNamePtr *string
+	var newLogicalName string
+	if req.FilePurpose == files.FilePurposeWorkflow {
+		if req.WorkflowName != nil {
+			newLogicalName = deriveLogicalName(req.FileName, *req.WorkflowName)
+			workflowNamePtr = req.WorkflowName
+		} else {
+			newLogicalName = extractLogicalName(configMap)
+			workflowNamePtr = nil
+		}
+	} else {
+		newLogicalName = req.FileName
+		workflowNamePtr = &req.FileName
 	}
-
-	newLogicalName := deriveLogicalName(req.FileName, workflowName)
 	oldLogicalName := extractLogicalName(configMap)
 	renamed := newLogicalName != oldLogicalName
 
@@ -469,7 +479,7 @@ func (h *Handler) UpdateFile(w http.ResponseWriter, r *http.Request) {
 		configMap.Annotations,
 		req.Description,
 		updatedBy,
-		&workflowName,
+		workflowNamePtr,
 	)
 
 	// Update data

--- a/internal/api/files_handlers_test.go
+++ b/internal/api/files_handlers_test.go
@@ -1491,10 +1491,11 @@ func TestCreateFile_ResiliencyPurpose(t *testing.T) {
 
 func TestCreateFile_InvalidFilePurpose(t *testing.T) {
 	handler := setupFilesTestHandler()
+	createTestAdminUser(handler)
 
 	createReq := files.CreateFileRequest{
 		FileName:       "invalid-purpose.yaml",
-		Content:        "data",
+		Content:        "key: value",
 		FilePurpose:    "unknown-purpose",
 		AvailableToAll: true,
 	}
@@ -1507,10 +1508,14 @@ func TestCreateFile_InvalidFilePurpose(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("Expected 400 for invalid filePurpose, got %d: %s", w.Code, w.Body.String())
 	}
+	if !strings.Contains(w.Body.String(), "Invalid filePurpose") {
+		t.Errorf("Expected error about invalid filePurpose, got: %s", w.Body.String())
+	}
 }
 
 func TestCreateFile_WorkflowPurposeBlocked(t *testing.T) {
 	handler := setupFilesTestHandler()
+	createTestAdminUser(handler)
 
 	createReq := files.CreateFileRequest{
 		FileName:       "sneaky-workflow.json",
@@ -1526,5 +1531,8 @@ func TestCreateFile_WorkflowPurposeBlocked(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("Expected 400 for workflow-template via files API, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "POST /api/v1/workflows") {
+		t.Errorf("Expected error about using workflows API, got: %s", w.Body.String())
 	}
 }

--- a/internal/api/files_handlers_test.go
+++ b/internal/api/files_handlers_test.go
@@ -1237,3 +1237,294 @@ func TestCanAccessFile(t *testing.T) {
 		})
 	}
 }
+
+// createTestAdminUser creates an admin KrknUser in the fake client for validation
+func createTestAdminUser(handler *Handler) {
+	user := &krknv1alpha1.KrknUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "krknuser-" + sanitizeUserID("admin@test.example"),
+			Namespace: handler.namespace,
+		},
+		Spec: krknv1alpha1.KrknUserSpec{
+			UserID: "admin@test.example",
+			Role:   "admin",
+		},
+	}
+	_ = handler.client.Create(context.Background(), user)
+}
+
+func TestCreateFile_DuplicateName(t *testing.T) {
+	handler := setupFilesTestHandler()
+	createTestAdminUser(handler)
+
+	createReq := files.CreateFileRequest{
+		FileName:       "unique-config.yaml",
+		Content:        "key: value",
+		AvailableToAll: true,
+	}
+	body, _ := json.Marshal(createReq)
+	req := httptest.NewRequest(http.MethodPost, FilesPath, bytes.NewReader(body))
+	req = addAdminContext(req)
+	w := httptest.NewRecorder()
+	handler.CreateFile(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("Setup: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Second create with the same fileName should return 409
+	body, _ = json.Marshal(createReq)
+	req = httptest.NewRequest(http.MethodPost, FilesPath, bytes.NewReader(body))
+	req = addAdminContext(req)
+	w = httptest.NewRecorder()
+	handler.CreateFile(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("Expected 409 Conflict for duplicate name, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateFile_DuplicateName_CrossPurpose(t *testing.T) {
+	handler := setupFilesTestHandler()
+	createTestAdminUser(handler)
+
+	// Create a generic file
+	createReq := files.CreateFileRequest{
+		FileName:       "cross-purpose.yaml",
+		Content:        "data: value",
+		FilePurpose:    files.FilePurposeFile,
+		AvailableToAll: true,
+	}
+	body, _ := json.Marshal(createReq)
+	req := httptest.NewRequest(http.MethodPost, FilesPath, bytes.NewReader(body))
+	req = addAdminContext(req)
+	w := httptest.NewRecorder()
+	handler.CreateFile(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("Setup: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Create a resiliency file with same fileName — should still conflict (global uniqueness)
+	createReq2 := files.CreateFileRequest{
+		FileName:       "cross-purpose.yaml",
+		Content:        "metrics: true",
+		FilePurpose:    files.FilePurposeResiliency,
+		AvailableToAll: true,
+	}
+	body, _ = json.Marshal(createReq2)
+	req = httptest.NewRequest(http.MethodPost, FilesPath, bytes.NewReader(body))
+	req = addAdminContext(req)
+	w = httptest.NewRecorder()
+	handler.CreateFile(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("Expected 409 Conflict across filePurpose, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateFile_RenameConflict(t *testing.T) {
+	handler := setupFilesTestHandler()
+	createTestAdminUser(handler)
+
+	// Create file A
+	reqA := files.CreateFileRequest{
+		FileName:       "file-a.yaml",
+		Content:        "key: a",
+		AvailableToAll: true,
+	}
+	body, _ := json.Marshal(reqA)
+	req := httptest.NewRequest(http.MethodPost, FilesPath, bytes.NewReader(body))
+	req = addAdminContext(req)
+	w := httptest.NewRecorder()
+	handler.CreateFile(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("Setup file A: expected 201, got %d", w.Code)
+	}
+
+	// Create file B
+	reqB := files.CreateFileRequest{
+		FileName:       "file-b.yaml",
+		Content:        "key: b",
+		AvailableToAll: true,
+	}
+	body, _ = json.Marshal(reqB)
+	req = httptest.NewRequest(http.MethodPost, FilesPath, bytes.NewReader(body))
+	req = addAdminContext(req)
+	w = httptest.NewRecorder()
+	handler.CreateFile(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("Setup file B: expected 201, got %d", w.Code)
+	}
+	var respB files.CreateFileResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &respB)
+
+	// Rename file B to file-a.yaml — should conflict
+	updateReq := files.UpdateFileRequest{
+		FileName:       "file-a.yaml",
+		Content:        "key: b-updated",
+		AvailableToAll: true,
+	}
+	body, _ = json.Marshal(updateReq)
+	req = httptest.NewRequest(http.MethodPut, FilesPath+"/"+respB.FileID, bytes.NewReader(body))
+	req = addAdminContext(req)
+	w = httptest.NewRecorder()
+	handler.UpdateFile(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("Expected 409 Conflict on rename to existing name, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateFile_SameName(t *testing.T) {
+	handler := setupFilesTestHandler()
+	createTestAdminUser(handler)
+
+	// Create file
+	createReq := files.CreateFileRequest{
+		FileName:       "keep-name.yaml",
+		Content:        "key: original",
+		AvailableToAll: true,
+	}
+	body, _ := json.Marshal(createReq)
+	req := httptest.NewRequest(http.MethodPost, FilesPath, bytes.NewReader(body))
+	req = addAdminContext(req)
+	w := httptest.NewRecorder()
+	handler.CreateFile(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("Setup: expected 201, got %d", w.Code)
+	}
+	var resp files.CreateFileResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+
+	// Update content but keep same fileName — should succeed
+	updateReq := files.UpdateFileRequest{
+		FileName:       "keep-name.yaml",
+		Content:        "key: updated",
+		AvailableToAll: true,
+	}
+	body, _ = json.Marshal(updateReq)
+	req = httptest.NewRequest(http.MethodPut, FilesPath+"/"+resp.FileID, bytes.NewReader(body))
+	req = addAdminContext(req)
+	w = httptest.NewRecorder()
+	handler.UpdateFile(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected 200 OK when keeping same name, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateFile_DefaultFilePurpose(t *testing.T) {
+	handler := setupFilesTestHandler()
+	createTestAdminUser(handler)
+
+	createReq := files.CreateFileRequest{
+		FileName:       "no-purpose.yaml",
+		Content:        "data: value",
+		AvailableToAll: true,
+	}
+	body, _ := json.Marshal(createReq)
+	req := httptest.NewRequest(http.MethodPost, FilesPath, bytes.NewReader(body))
+	req = addAdminContext(req)
+	w := httptest.NewRecorder()
+	handler.CreateFile(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("Expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp files.CreateFileResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+
+	// Verify the ConfigMap has filePurpose label set to "file"
+	var cm corev1.ConfigMap
+	err := handler.client.Get(context.Background(), client.ObjectKey{
+		Name:      "file-" + resp.FileID,
+		Namespace: handler.namespace,
+	}, &cm)
+	if err != nil {
+		t.Fatalf("Failed to get ConfigMap: %v", err)
+	}
+
+	if cm.Labels[files.FilePurposeLabel] != files.FilePurposeFile {
+		t.Errorf("Expected filePurpose label '%s', got '%s'", files.FilePurposeFile, cm.Labels[files.FilePurposeLabel])
+	}
+}
+
+func TestCreateFile_ResiliencyPurpose(t *testing.T) {
+	handler := setupFilesTestHandler()
+	createTestAdminUser(handler)
+
+	createReq := files.CreateFileRequest{
+		FileName:       "resiliency-metrics.yaml",
+		Content:        "metrics: true",
+		FilePurpose:    files.FilePurposeResiliency,
+		AvailableToAll: true,
+	}
+	body, _ := json.Marshal(createReq)
+	req := httptest.NewRequest(http.MethodPost, FilesPath, bytes.NewReader(body))
+	req = addAdminContext(req)
+	w := httptest.NewRecorder()
+	handler.CreateFile(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("Expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp files.CreateFileResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+
+	// Verify the ConfigMap has filePurpose label set to "resiliency-score"
+	var cm corev1.ConfigMap
+	err := handler.client.Get(context.Background(), client.ObjectKey{
+		Name:      "file-" + resp.FileID,
+		Namespace: handler.namespace,
+	}, &cm)
+	if err != nil {
+		t.Fatalf("Failed to get ConfigMap: %v", err)
+	}
+
+	if cm.Labels[files.FilePurposeLabel] != files.FilePurposeResiliency {
+		t.Errorf("Expected filePurpose label '%s', got '%s'", files.FilePurposeResiliency, cm.Labels[files.FilePurposeLabel])
+	}
+}
+
+func TestCreateFile_InvalidFilePurpose(t *testing.T) {
+	handler := setupFilesTestHandler()
+
+	createReq := files.CreateFileRequest{
+		FileName:       "invalid-purpose.yaml",
+		Content:        "data",
+		FilePurpose:    "unknown-purpose",
+		AvailableToAll: true,
+	}
+	body, _ := json.Marshal(createReq)
+	req := httptest.NewRequest(http.MethodPost, FilesPath, bytes.NewReader(body))
+	req = addAdminContext(req)
+	w := httptest.NewRecorder()
+	handler.CreateFile(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected 400 for invalid filePurpose, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateFile_WorkflowPurposeBlocked(t *testing.T) {
+	handler := setupFilesTestHandler()
+
+	createReq := files.CreateFileRequest{
+		FileName:       "sneaky-workflow.json",
+		Content:        `{"nodes": []}`,
+		FilePurpose:    files.FilePurposeWorkflow,
+		AvailableToAll: true,
+	}
+	body, _ := json.Marshal(createReq)
+	req := httptest.NewRequest(http.MethodPost, FilesPath, bytes.NewReader(body))
+	req = addAdminContext(req)
+	w := httptest.NewRecorder()
+	handler.CreateFile(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected 400 for workflow-template via files API, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package api
 
 import (
+	"fmt"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,6 +44,16 @@ type NodesResponse struct {
 type ErrorResponse struct {
 	Error   string `json:"error"`
 	Message string `json:"message"`
+}
+
+// DuplicateFileError is returned when a file with the same logical name already exists
+type DuplicateFileError struct {
+	Name       string
+	ExistingID string
+}
+
+func (e *DuplicateFileError) Error() string {
+	return fmt.Sprintf("a file with name '%s' already exists (ID: %s)", e.Name, e.ExistingID)
 }
 
 // ScenariosRequest represents the optional request body for POST /scenarios

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -53,7 +53,7 @@ type DuplicateFileError struct {
 }
 
 func (e *DuplicateFileError) Error() string {
-	return fmt.Sprintf("a file with name '%s' already exists (ID: %s)", e.Name, e.ExistingID)
+	return fmt.Sprintf("a file with name '%s' already exists", e.Name)
 }
 
 // ScenariosRequest represents the optional request body for POST /scenarios

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -52,6 +52,7 @@ type DuplicateFileError struct {
 	ExistingID string
 }
 
+// Error implements the error interface for DuplicateFileError.
 func (e *DuplicateFileError) Error() string {
 	return fmt.Sprintf("a file with name '%s' already exists", e.Name)
 }

--- a/internal/api/workflow_fixes_test.go
+++ b/internal/api/workflow_fixes_test.go
@@ -34,12 +34,15 @@ func TestBuildFileInfo_ExcludesStudioLayout(t *testing.T) {
 		wantFileName string
 	}{
 		{
-			name: "workflow with studioLayout - should return workflow.json",
+			name: "workflow with studioLayout - should return logical name from annotation",
 			configMap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-workflow",
 					Labels: map[string]string{
 						files.FileIDLabel: "test-123",
+					},
+					Annotations: map[string]string{
+						files.WorkflowNameAnnotation: "My Workflow",
 					},
 				},
 				Data: map[string]string{
@@ -47,15 +50,18 @@ func TestBuildFileInfo_ExcludesStudioLayout(t *testing.T) {
 					"studioLayout.json": `{"positions": {}}`,
 				},
 			},
-			wantFileName: "workflow.json",
+			wantFileName: "My Workflow",
 		},
 		{
-			name: "file without studioLayout - should return filename",
+			name: "file without studioLayout - should return logical name from annotation",
 			configMap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-file",
 					Labels: map[string]string{
 						files.FileIDLabel: "test-456",
+					},
+					Annotations: map[string]string{
+						files.WorkflowNameAnnotation: "config.yaml",
 					},
 				},
 				Data: map[string]string{
@@ -65,7 +71,7 @@ func TestBuildFileInfo_ExcludesStudioLayout(t *testing.T) {
 			wantFileName: "config.yaml",
 		},
 		{
-			name: "only studioLayout - should return empty",
+			name: "no annotation - should return empty",
 			configMap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-broken",
@@ -91,7 +97,7 @@ func TestBuildFileInfo_ExcludesStudioLayout(t *testing.T) {
 	}
 }
 
-// Test for Bug Fix #2: WorkflowName fallback for backwards compatibility
+// Test for Bug Fix #2: WorkflowName/FileName read from annotation for all files
 func TestBuildFileResponse_WorkflowNameFallback(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -99,7 +105,7 @@ func TestBuildFileResponse_WorkflowNameFallback(t *testing.T) {
 		wantWorkflowName string
 	}{
 		{
-			name: "workflow with annotation - use annotation",
+			name: "workflow with annotation",
 			configMap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-workflow",
@@ -118,37 +124,22 @@ func TestBuildFileResponse_WorkflowNameFallback(t *testing.T) {
 			wantWorkflowName: "My Custom Workflow",
 		},
 		{
-			name: "workflow without annotation - fallback to fileName",
-			configMap: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-workflow-old",
-					Labels: map[string]string{
-						files.FileIDLabel:      "test-456",
-						files.FilePurposeLabel: "workflow-template",
-					},
-					Annotations: map[string]string{},
-				},
-				Data: map[string]string{
-					"workflow.json": `{"node1": {}}`,
-				},
-			},
-			wantWorkflowName: "workflow.json",
-		},
-		{
-			name: "regular file without annotation - no fallback",
+			name: "regular file with annotation",
 			configMap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-file",
 					Labels: map[string]string{
 						files.FileIDLabel: "test-789",
 					},
-					Annotations: map[string]string{},
+					Annotations: map[string]string{
+						files.WorkflowNameAnnotation: "config.yaml",
+					},
 				},
 				Data: map[string]string{
 					"config.yaml": `key: value`,
 				},
 			},
-			wantWorkflowName: "",
+			wantWorkflowName: "config.yaml",
 		},
 	}
 

--- a/internal/api/workflow_handlers.go
+++ b/internal/api/workflow_handlers.go
@@ -31,6 +31,7 @@ import (
 	"github.com/krkn-chaos/krkn-operator/pkg/files"
 	"github.com/krkn-chaos/krkn-operator/pkg/workflows"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -590,18 +591,17 @@ func (h *Handler) createFileInternal(ctx context.Context, req files.CreateFileRe
 		return nil, err
 	}
 
-	// Check for duplicate logical name (global uniqueness)
-	logicalName := deriveLogicalName(req.FileName, req.WorkflowName)
-	existingID, err := h.checkDuplicateLogicalName(ctx, logicalName, "")
-	if err != nil {
-		return nil, fmt.Errorf("failed to check for duplicate file name: %w", err)
-	}
-	if existingID != "" {
-		return nil, &DuplicateFileError{Name: logicalName, ExistingID: existingID}
-	}
-
 	// Generate unique file ID (UUID)
 	fileID := uuid.New().String()
+
+	// Atomically reserve the logical name (prevents concurrent duplicates)
+	logicalName := deriveLogicalName(req.FileName, req.WorkflowName)
+	if err := h.reserveLogicalName(ctx, logicalName, fileID); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return nil, &DuplicateFileError{Name: logicalName}
+		}
+		return nil, fmt.Errorf("failed to reserve logical name: %w", err)
+	}
 	configMapName := fmt.Sprintf("file-%s", fileID)
 	createdBy := claims.UserID
 
@@ -638,6 +638,9 @@ func (h *Handler) createFileInternal(ctx context.Context, req files.CreateFileRe
 	}
 
 	if err := h.client.Create(ctx, configMap); err != nil {
+		if releaseErr := h.releaseLogicalName(ctx, logicalName); releaseErr != nil {
+			logger.Error(releaseErr, "Failed to release reservation after file creation failure", "logicalName", logicalName)
+		}
 		return nil, fmt.Errorf("failed to create file ConfigMap: %w", err)
 	}
 
@@ -813,18 +816,23 @@ func (h *Handler) updateFileInternal(ctx context.Context, fileID string, req fil
 		return fmt.Errorf("only the workflow owner or an admin can update this workflow")
 	}
 
-	// Check for duplicate logical name on rename (exclude current file)
+	// Derive logical names for rename detection
 	workflowName := ""
 	if req.WorkflowName != nil {
 		workflowName = *req.WorkflowName
 	}
-	logicalName := deriveLogicalName(req.FileName, workflowName)
-	existingID, err := h.checkDuplicateLogicalName(ctx, logicalName, fileID)
-	if err != nil {
-		return fmt.Errorf("failed to check for duplicate file name: %w", err)
-	}
-	if existingID != "" {
-		return &DuplicateFileError{Name: logicalName, ExistingID: existingID}
+	newLogicalName := deriveLogicalName(req.FileName, workflowName)
+	oldLogicalName := extractLogicalName(configMap)
+	renamed := newLogicalName != oldLogicalName
+
+	// On rename, atomically reserve the new name
+	if renamed {
+		if err := h.reserveLogicalName(ctx, newLogicalName, fileID); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				return &DuplicateFileError{Name: newLogicalName}
+			}
+			return fmt.Errorf("failed to reserve logical name: %w", err)
+		}
 	}
 
 	// Get current user for audit trail
@@ -839,7 +847,7 @@ func (h *Handler) updateFileInternal(ctx context.Context, fileID string, req fil
 	}
 
 	// Update labels and annotations (preserve existing file ID)
-	configMap.Labels = files.BuildFileLabels(fileID, req.FileType, req.Groups, req.AvailableToAll, req.FilePurpose, logicalName)
+	configMap.Labels = files.BuildFileLabels(fileID, req.FileType, req.Groups, req.AvailableToAll, req.FilePurpose, newLogicalName)
 	configMap.Annotations = files.UpdateFileAnnotations(
 		configMap.Annotations,
 		req.Description,
@@ -858,7 +866,20 @@ func (h *Handler) updateFileInternal(ctx context.Context, fileID string, req fil
 	configMap.Data = data
 
 	if err := h.client.Update(ctx, configMap); err != nil {
+		// Rollback new reservation on failure
+		if renamed {
+			if releaseErr := h.releaseLogicalName(ctx, newLogicalName); releaseErr != nil {
+				logger.Error(releaseErr, "Failed to release new reservation after update failure", "logicalName", newLogicalName)
+			}
+		}
 		return fmt.Errorf("failed to update file: %w", err)
+	}
+
+	// Release old reservation on successful rename
+	if renamed && oldLogicalName != "" {
+		if err := h.releaseLogicalName(ctx, oldLogicalName); err != nil {
+			logger.Error(err, "Failed to release old name reservation", "logicalName", oldLogicalName)
+		}
 	}
 
 	logger.Info("Updated file", "fileID", fileID, "updatedBy", updatedBy)
@@ -887,6 +908,14 @@ func (h *Handler) deleteFileInternal(ctx context.Context, fileID string) error {
 	// Delete ConfigMap
 	if err := h.client.Delete(ctx, configMap); err != nil {
 		return fmt.Errorf("failed to delete file: %w", err)
+	}
+
+	// Release the logical name reservation
+	logicalName := extractLogicalName(configMap)
+	if logicalName != "" {
+		if err := h.releaseLogicalName(ctx, logicalName); err != nil {
+			logger.Error(err, "Failed to release name reservation", "logicalName", logicalName, "fileID", fileID)
+		}
 	}
 
 	logger.Info("Deleted file", "fileID", fileID)

--- a/internal/api/workflow_handlers.go
+++ b/internal/api/workflow_handlers.go
@@ -21,6 +21,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -46,6 +47,7 @@ import (
 // @Success 201 {object} workflows.CreateWorkflowResponse "Workflow created"
 // @Failure 400 {object} ErrorResponse "Invalid request or graph validation error"
 // @Failure 401 {object} ErrorResponse "Unauthorized"
+// @Failure 409 {object} ErrorResponse "Workflow name already exists"
 // @Failure 500 {object} ErrorResponse "Internal server error"
 // @Router /workflows [post]
 func (h *Handler) CreateWorkflow(w http.ResponseWriter, r *http.Request) {
@@ -122,17 +124,24 @@ func (h *Handler) CreateWorkflow(w http.ResponseWriter, r *http.Request) {
 		StudioLayout:   studioLayoutJSON, // Studio visual layout (optional)
 		WorkflowName:   req.WorkflowName, // User-defined workflow name
 		Description:    req.Description,
-		FileType:       req.FileType,        // User categorization (optional)
-		Groups:         req.Groups,          // RBAC groups
-		AvailableToAll: req.AvailableToAll,  // Public flag
-		FilePurpose:    "workflow-template", // System marker
+		FileType:       req.FileType,              // User categorization (optional)
+		Groups:         req.Groups,                // RBAC groups
+		AvailableToAll: req.AvailableToAll,        // Public flag
+		FilePurpose:    files.FilePurposeWorkflow, // System marker
 	}
 
 	// Call existing CreateFile handler logic
 	fileResp, err := h.createFileInternal(ctx, fileReq)
 	if err != nil {
+		var dupErr *DuplicateFileError
+		if errors.As(err, &dupErr) {
+			writeJSONError(w, http.StatusConflict, ErrorResponse{
+				Error:   "conflict",
+				Message: dupErr.Error(),
+			})
+			return
+		}
 		// Distinguish validation errors (4xx) from internal errors (5xx)
-		// Only known validation errors should return 400
 		statusCode := http.StatusInternalServerError
 		errorCode := "internal_error"
 		if strings.Contains(err.Error(), "you can only assign files to your own group") {
@@ -212,7 +221,7 @@ func (h *Handler) ListWorkflows(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Call file list with filePurpose filter
-	fileList, err := h.listFilesInternal(ctx, "workflow-template")
+	fileList, err := h.listFilesInternal(ctx, files.FilePurposeWorkflow)
 	if err != nil {
 		logger.Error(err, "Failed to list workflow files")
 		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
@@ -265,7 +274,7 @@ func (h *Handler) ListAvailableWorkflows(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Call file list with filePurpose filter (returns ConfigMaps)
-	configMaps, err := h.listAvailableFilesInternal(ctx, "workflow-template")
+	configMaps, err := h.listAvailableFilesInternal(ctx, files.FilePurposeWorkflow)
 	if err != nil {
 		logger.Error(err, "Failed to list available workflow files")
 		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
@@ -315,7 +324,7 @@ func (h *Handler) GetWorkflow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Verify it's a workflow file
-	if fileResp.FilePurpose != "workflow-template" {
+	if fileResp.FilePurpose != files.FilePurposeWorkflow {
 		writeJSONError(w, http.StatusBadRequest, ErrorResponse{
 			Error:   "bad_request",
 			Message: "File is not a workflow template",
@@ -418,11 +427,19 @@ func (h *Handler) UpdateWorkflow(w http.ResponseWriter, r *http.Request) {
 		FileType:       req.FileType,
 		Groups:         req.Groups,
 		AvailableToAll: req.AvailableToAll,
-		FilePurpose:    "workflow-template",
+		FilePurpose:    files.FilePurposeWorkflow,
 	}
 
 	err = h.updateFileInternal(ctx, workflowID, fileReq)
 	if err != nil {
+		var dupErr *DuplicateFileError
+		if errors.As(err, &dupErr) {
+			writeJSONError(w, http.StatusConflict, ErrorResponse{
+				Error:   "conflict",
+				Message: dupErr.Error(),
+			})
+			return
+		}
 		logger.Error(err, "Failed to update workflow", "workflowID", workflowID)
 		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
 			Error:   "internal_error",
@@ -466,7 +483,7 @@ func (h *Handler) DeleteWorkflow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check file purpose
-	if files.ExtractFilePurposeFromLabels(configMap.Labels) != "workflow-template" {
+	if files.ExtractFilePurposeFromLabels(configMap.Labels) != files.FilePurposeWorkflow {
 		writeJSONError(w, http.StatusBadRequest, ErrorResponse{
 			Error:   "bad_request",
 			Message: "File is not a workflow template",
@@ -571,6 +588,16 @@ func (h *Handler) createFileInternal(ctx context.Context, req files.CreateFileRe
 	// Validate request
 	if err := validateCreateFileRequest(ctx, h.client, &req, h.namespace, isAdmin, claims.UserID); err != nil {
 		return nil, err
+	}
+
+	// Check for duplicate logical name (global uniqueness)
+	logicalName := deriveLogicalName(req.FileName, req.WorkflowName)
+	existingID, err := h.checkDuplicateLogicalName(ctx, logicalName, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to check for duplicate file name: %w", err)
+	}
+	if existingID != "" {
+		return nil, &DuplicateFileError{Name: logicalName, ExistingID: existingID}
 	}
 
 	// Generate unique file ID (UUID)
@@ -770,9 +797,9 @@ func (h *Handler) updateFileInternal(ctx context.Context, fileID string, req fil
 
 	// Verify file purpose matches expected type (only for workflow operations)
 	// This prevents workflow endpoints from mutating non-workflow files
-	if req.FilePurpose == "workflow-template" {
+	if req.FilePurpose == files.FilePurposeWorkflow {
 		existingPurpose := files.ExtractFilePurposeFromLabels(configMap.Labels)
-		if existingPurpose != "workflow-template" {
+		if existingPurpose != files.FilePurposeWorkflow {
 			return fmt.Errorf("cannot update non-workflow file via workflow API")
 		}
 	}
@@ -784,6 +811,20 @@ func (h *Handler) updateFileInternal(ctx context.Context, fileID string, req fil
 	}
 	if !isOwner {
 		return fmt.Errorf("only the workflow owner or an admin can update this workflow")
+	}
+
+	// Check for duplicate logical name on rename (exclude current file)
+	workflowName := ""
+	if req.WorkflowName != nil {
+		workflowName = *req.WorkflowName
+	}
+	logicalName := deriveLogicalName(req.FileName, workflowName)
+	existingID, err := h.checkDuplicateLogicalName(ctx, logicalName, fileID)
+	if err != nil {
+		return fmt.Errorf("failed to check for duplicate file name: %w", err)
+	}
+	if existingID != "" {
+		return &DuplicateFileError{Name: logicalName, ExistingID: existingID}
 	}
 
 	// Get current user for audit trail

--- a/internal/api/workflow_handlers.go
+++ b/internal/api/workflow_handlers.go
@@ -614,7 +614,7 @@ func (h *Handler) createFileInternal(ctx context.Context, req files.CreateFileRe
 	}
 
 	// Build labels and annotations
-	labels := files.BuildFileLabels(fileID, req.FileType, req.Groups, req.AvailableToAll, req.FilePurpose)
+	labels := files.BuildFileLabels(fileID, req.FileType, req.Groups, req.AvailableToAll, req.FilePurpose, logicalName)
 	annotations := files.BuildFileAnnotations(req.Description, createdBy, req.WorkflowName)
 
 	// Build ConfigMap data
@@ -839,7 +839,7 @@ func (h *Handler) updateFileInternal(ctx context.Context, fileID string, req fil
 	}
 
 	// Update labels and annotations (preserve existing file ID)
-	configMap.Labels = files.BuildFileLabels(fileID, req.FileType, req.Groups, req.AvailableToAll, req.FilePurpose)
+	configMap.Labels = files.BuildFileLabels(fileID, req.FileType, req.Groups, req.AvailableToAll, req.FilePurpose, logicalName)
 	configMap.Annotations = files.UpdateFileAnnotations(
 		configMap.Annotations,
 		req.Description,

--- a/internal/api/workflow_handlers_test.go
+++ b/internal/api/workflow_handlers_test.go
@@ -822,3 +822,116 @@ func TestWorkflowStudioLayout(t *testing.T) {
 		t.Errorf("Expected nextNodeNumber=4 after update, got %v", getResp2.StudioLayout["nextNodeNumber"])
 	}
 }
+
+func TestCreateWorkflow_DuplicateName(t *testing.T) {
+	handler := setupWorkflowTestHandler()
+
+	// Create user
+	user := &krknv1alpha1.KrknUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "krknuser-" + sanitizeUserID("admin@test.example"),
+			Namespace: handler.namespace,
+		},
+		Spec: krknv1alpha1.KrknUserSpec{
+			UserID: "admin@test.example",
+		},
+	}
+	_ = handler.client.Create(context.Background(), user)
+
+	req1 := workflows.CreateWorkflowRequest{
+		WorkflowName:   "My Workflow",
+		Description:    "first",
+		Graph:          validWorkflowGraph(),
+		AvailableToAll: true,
+	}
+	body, _ := json.Marshal(req1)
+	httpReq := httptest.NewRequest(http.MethodPost, WorkflowsPath, bytes.NewReader(body))
+	httpReq = addAdminContext(httpReq)
+	w := httptest.NewRecorder()
+	handler.CreateWorkflow(w, httpReq)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("Setup: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Second workflow with same name should return 409
+	req2 := workflows.CreateWorkflowRequest{
+		WorkflowName:   "My Workflow",
+		Description:    "duplicate",
+		Graph:          validWorkflowGraph(),
+		AvailableToAll: true,
+	}
+	body, _ = json.Marshal(req2)
+	httpReq = httptest.NewRequest(http.MethodPost, WorkflowsPath, bytes.NewReader(body))
+	httpReq = addAdminContext(httpReq)
+	w = httptest.NewRecorder()
+	handler.CreateWorkflow(w, httpReq)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("Expected 409 Conflict for duplicate workflow name, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateWorkflow_RenameConflict(t *testing.T) {
+	handler := setupWorkflowTestHandler()
+
+	// Create user
+	user := &krknv1alpha1.KrknUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "krknuser-" + sanitizeUserID("admin@test.example"),
+			Namespace: handler.namespace,
+		},
+		Spec: krknv1alpha1.KrknUserSpec{
+			UserID: "admin@test.example",
+		},
+	}
+	_ = handler.client.Create(context.Background(), user)
+
+	// Create workflow A
+	reqA := workflows.CreateWorkflowRequest{
+		WorkflowName:   "Workflow Alpha",
+		Graph:          validWorkflowGraph(),
+		AvailableToAll: true,
+	}
+	body, _ := json.Marshal(reqA)
+	httpReq := httptest.NewRequest(http.MethodPost, WorkflowsPath, bytes.NewReader(body))
+	httpReq = addAdminContext(httpReq)
+	w := httptest.NewRecorder()
+	handler.CreateWorkflow(w, httpReq)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("Setup workflow A: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Create workflow B
+	reqB := workflows.CreateWorkflowRequest{
+		WorkflowName:   "Workflow Beta",
+		Graph:          validWorkflowGraph(),
+		AvailableToAll: true,
+	}
+	body, _ = json.Marshal(reqB)
+	httpReq = httptest.NewRequest(http.MethodPost, WorkflowsPath, bytes.NewReader(body))
+	httpReq = addAdminContext(httpReq)
+	w = httptest.NewRecorder()
+	handler.CreateWorkflow(w, httpReq)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("Setup workflow B: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var respB workflows.CreateWorkflowResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &respB)
+
+	// Rename workflow B to "Workflow Alpha" — should conflict
+	updateReq := workflows.UpdateWorkflowRequest{
+		WorkflowName:   "Workflow Alpha",
+		Graph:          validWorkflowGraph(),
+		AvailableToAll: true,
+	}
+	body, _ = json.Marshal(updateReq)
+	httpReq = httptest.NewRequest(http.MethodPut, WorkflowsPath+"/"+respB.WorkflowID, bytes.NewReader(body))
+	httpReq = addAdminContext(httpReq)
+	w = httptest.NewRecorder()
+	handler.UpdateWorkflow(w, httpReq)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("Expected 409 Conflict on rename to existing workflow name, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/pkg/files/labels.go
+++ b/pkg/files/labels.go
@@ -17,6 +17,8 @@ limitations under the License.
 package files
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"strings"
 	"time"
 
@@ -37,6 +39,8 @@ const (
 	FileIDLabel = "files.krkn.krkn-chaos.dev/file-id"
 	// FilePurposeLabel identifies the purpose/type of file (e.g., "workflow-template")
 	FilePurposeLabel = "files.krkn.krkn-chaos.dev/file-purpose"
+	// LogicalNameHashLabel stores a SHA256 prefix of the logical name for efficient server-side dedup queries
+	LogicalNameHashLabel = "files.krkn.krkn-chaos.dev/logical-name-hash"
 
 	// DescriptionAnnotation stores the file description
 	DescriptionAnnotation = "files.krkn.krkn-chaos.dev/description"
@@ -64,8 +68,15 @@ const (
 	FilePurposeResiliency = "resiliency-score"
 )
 
+// HashLogicalName returns a truncated SHA256 hex digest of the logical name,
+// safe for use as a Kubernetes label value (max 63 chars, RFC 1123).
+func HashLogicalName(name string) string {
+	h := sha256.Sum256([]byte(name))
+	return hex.EncodeToString(h[:16])
+}
+
 // BuildFileLabels creates the labels map for a file ConfigMap
-func BuildFileLabels(fileID, fileType string, groups []string, availableToAll bool, filePurpose string) map[string]string {
+func BuildFileLabels(fileID, fileType string, groups []string, availableToAll bool, filePurpose, logicalName string) map[string]string {
 	labels := map[string]string{
 		AppNameLabel:      AppName,
 		AppComponentLabel: ComponentFile,
@@ -92,6 +103,11 @@ func BuildFileLabels(fileID, fileType string, groups []string, availableToAll bo
 	// Add file purpose label if specified
 	if filePurpose != "" {
 		labels[FilePurposeLabel] = filePurpose
+	}
+
+	// Add logical name hash for efficient server-side dedup queries
+	if logicalName != "" {
+		labels[LogicalNameHashLabel] = HashLogicalName(logicalName)
 	}
 
 	return labels

--- a/pkg/files/labels.go
+++ b/pkg/files/labels.go
@@ -55,6 +55,13 @@ const (
 	AppName = "krkn-operator"
 	// ComponentFile is the value for AppComponentLabel
 	ComponentFile = "file"
+
+	// FilePurposeFile is the filePurpose value for generic user files
+	FilePurposeFile = "file"
+	// FilePurposeWorkflow is the filePurpose value for workflow graph templates
+	FilePurposeWorkflow = "workflow-template"
+	// FilePurposeResiliency is the filePurpose value for resiliency scoring metric definitions
+	FilePurposeResiliency = "resiliency-score"
 )
 
 // BuildFileLabels creates the labels map for a file ConfigMap
@@ -209,4 +216,19 @@ func ExtractFileTypeFromLabels(labels map[string]string) string {
 // Returns empty string if no file purpose label is found
 func ExtractFilePurposeFromLabels(labels map[string]string) string {
 	return labels[FilePurposeLabel]
+}
+
+// ValidFilePurposes returns all valid filePurpose values
+func ValidFilePurposes() []string {
+	return []string{FilePurposeFile, FilePurposeWorkflow, FilePurposeResiliency}
+}
+
+// IsValidFilePurpose checks if a filePurpose value is valid
+func IsValidFilePurpose(purpose string) bool {
+	for _, valid := range ValidFilePurposes() {
+		if purpose == valid {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/files/labels.go
+++ b/pkg/files/labels.go
@@ -59,6 +59,8 @@ const (
 	AppName = "krkn-operator"
 	// ComponentFile is the value for AppComponentLabel
 	ComponentFile = "file"
+	// ComponentFileReservation is the component label for name reservation ConfigMaps
+	ComponentFileReservation = "file-reservation"
 
 	// FilePurposeFile is the filePurpose value for generic user files
 	FilePurposeFile = "file"
@@ -73,6 +75,11 @@ const (
 func HashLogicalName(name string) string {
 	h := sha256.Sum256([]byte(name))
 	return hex.EncodeToString(h[:16])
+}
+
+// ReservationName returns the deterministic ConfigMap name for a logical name reservation.
+func ReservationName(logicalName string) string {
+	return "file-reservation-" + HashLogicalName(logicalName)
 }
 
 // BuildFileLabels creates the labels map for a file ConfigMap


### PR DESCRIPTION
Add global file name uniqueness enforcement returning HTTP 409 Conflict on duplicate logical names across all filePurpose types. Introduce filePurpose constants (file, workflow-template, resiliency-score) with defaulting, validation, and blocking of workflow-template via files API.