### PR TITLE
Adding namespace cache with start_operator

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -213,6 +213,13 @@ func main() {
 	}
 	setupLog.Info("KrknTargetRequest namespace", "namespace", krknNamespace)
 
+	cacheNamespaces := map[string]cache.Config{
+		operatorNamespace: {},
+	}
+	if krknNamespace != operatorNamespace {
+		cacheNamespaces[krknNamespace] = cache.Config{}
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                  scheme,
 		Metrics:                 metricsServerOptions,


### PR DESCRIPTION
When using ./start_operator, continuously hitting issues with namespace 

"The fix is in cmd/main.go:216-244. When KRKN_NAMESPACE=default (the start_operator.sh default) differs from operatorNamespace (krkn-operator-system), the cache now watches both namespaces, so the default/krkn-operator lookup no longer fails with "unknown namespace for the cache"."