### PR TITLE
Blocked scenarios that require cloud permissions

### DIFF
--- a/internal/api/blocked_scenarios.go
+++ b/internal/api/blocked_scenarios.go
@@ -1,0 +1,20 @@
+package api
+
+import "strings"
+
+var blockedScenarioPrefixes = []string{"node-scenarios"}
+var blockedScenariosExact = []string{"zone-outages", "power-outages"}
+
+func isScenarioBlocked(name string) bool {
+	for _, exact := range blockedScenariosExact {
+		if name == exact {
+			return true
+		}
+	}
+	for _, prefix := range blockedScenarioPrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/blocked_scenarios_test.go
+++ b/internal/api/blocked_scenarios_test.go
@@ -1,0 +1,31 @@
+package api
+
+import "testing"
+
+func TestIsScenarioBlocked(t *testing.T) {
+	tests := []struct {
+		name     string
+		scenario string
+		want     bool
+	}{
+		{"node-scenarios prefix blocks node-scenarios-bm", "node-scenarios-bm", true},
+		{"node-scenarios prefix blocks node-scenarios", "node-scenarios", true},
+		{"exact match blocks zone-outages", "zone-outages", true},
+		{"exact match blocks power-outages", "power-outages", true},
+		{"node- alone is now allowed", "node-cpu-hog", false},
+		{"node-drain is now allowed", "node-drain", false},
+		{"bare 'node' is not blocked", "node", false},
+		{"pod-disruption is allowed", "pod-disruption", false},
+		{"network-chaos is allowed", "network-chaos", false},
+		{"container-kill is allowed", "container-kill", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isScenarioBlocked(tt.scenario)
+			if got != tt.want {
+				t.Errorf("isScenarioBlocked(%q) = %v, want %v", tt.scenario, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -788,6 +788,9 @@ func (h *Handler) PostScenarios(w http.ResponseWriter, r *http.Request) {
 	scenarios := make([]ScenarioTag, 0)
 	if scenarioTags != nil {
 		for _, tag := range *scenarioTags {
+			if isScenarioBlocked(tag.Name) {
+				continue
+			}
 			scenarios = append(scenarios, ScenarioTag{
 				Name:         tag.Name,
 				Digest:       tag.Digest,
@@ -1061,6 +1064,14 @@ func (h *Handler) PostScenarioRun(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, ErrorResponse{
 			Error:   "bad_request",
 			Message: "scenarioName is required",
+		})
+		return
+	}
+
+	if isScenarioBlocked(req.ScenarioName) {
+		writeJSONError(w, http.StatusForbidden, ErrorResponse{
+			Error:   "forbidden",
+			Message: "This scenario type is not permitted",
 		})
 		return
 	}


### PR DESCRIPTION
Want to block scenarios that require cloud permissions as they aren't set up yet