### PR TITLE
jwt error fix

### DIFF
--- a/start_operator.sh
+++ b/start_operator.sh
@@ -85,8 +85,10 @@ run_operator() {
     print_info "Press Ctrl+C to stop the operator"
     echo ""
 
-    # Run the operator with custom flags and export KRKN_NAMESPACE
+    # Run the operator with custom flags and export namespaces
+    # POD_NAMESPACE must match KRKN_NAMESPACE so the manager cache covers the right namespace
     export KRKN_NAMESPACE
+    export POD_NAMESPACE="${POD_NAMESPACE:-$KRKN_NAMESPACE}"
     ./bin/manager \
         --api-port="$API_PORT" \
         --metrics-bind-address="$METRICS_ADDR" \


### PR DESCRIPTION

```
2026-08-03T15:14:15-04:00       INFO    Context cancelled while waiting for JWT secret
2026-08-03T15:14:15-04:00       INFO    jwt-secret-manager      Context cancelled during retry wait
2026-08-03T15:14:15-04:00       ERROR   jwt-secret-manager      ❌ FATAL: Failed to load or create JWT secret after all retries {"error": "context canceled"}
github.com/krkn-chaos/krkn-operator/pkg/auth.(*SecretManager).Start
        /Users/prubenda/Github/krkn-operator/pkg/auth/secret_manager.go:84
sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1
        /Users/prubenda/Github/krkn-operator/vendor/sigs.k8s.io/controller-runtime/pkg/manager/runnable_group.go:226
```

Changing in start_operator because I think this is in this specific script issue instead of https://github.com/krkn-chaos/krkn-operator/pull/59/changes
