### PR TITLE
fix(websocket): include ClusterJobs in lightweight broadcast and harden reconciler

### DIFF
--- a/internal/api/v2/websocket/broadcaster.go
+++ b/internal/api/v2/websocket/broadcaster.go
@@ -94,7 +94,7 @@ func (b *Broadcaster) BroadcastScenarioRunUpdate(scenarioRun *krknv1alpha1.KrknS
 		SuccessfulJobs:    scenarioRun.Status.SuccessfulJobs,
 		FailedJobs:        scenarioRun.Status.FailedJobs,
 		RunningJobs:       scenarioRun.Status.RunningJobs,
-		ClusterJobs:       nil, // WebSocket doesn't send cluster jobs details
+		ClusterJobs:       scenarioRun.Status.ClusterJobs,
 		OwnerUserID:       scenarioRun.Spec.OwnerUserID,
 		RegistryName:      scenarioRun.Spec.RegistryName,
 		GraphRunName:      scenarioRun.Labels["krkn.dev/graph-run"],

--- a/internal/api/v2/websocket/broadcaster.go
+++ b/internal/api/v2/websocket/broadcaster.go
@@ -86,21 +86,7 @@ func (b *Broadcaster) BroadcastScenarioRunUpdate(scenarioRun *krknv1alpha1.KrknS
 	}
 
 	// Status changed - broadcast and update cache
-	// Build the SAME response as REST API
-	response := ScenarioRunStatusResponse{
-		ScenarioRunName:   scenarioRun.Name,
-		Phase:             scenarioRun.Status.Phase,
-		TotalTargets:      scenarioRun.Status.TotalTargets,
-		SuccessfulJobs:    scenarioRun.Status.SuccessfulJobs,
-		FailedJobs:        scenarioRun.Status.FailedJobs,
-		RunningJobs:       scenarioRun.Status.RunningJobs,
-		ClusterJobs:       scenarioRun.Status.ClusterJobs,
-		OwnerUserID:       scenarioRun.Spec.OwnerUserID,
-		RegistryName:      scenarioRun.Spec.RegistryName,
-		GraphRunName:      scenarioRun.Labels["krkn.dev/graph-run"],
-		GraphNodeID:       scenarioRun.Labels["krkn.dev/graph-node"],
-		CreationTimestamp: scenarioRun.CreationTimestamp.Format(time.RFC3339),
-	}
+	response := buildScenarioRunResponse(scenarioRun)
 
 	msg := ServerMessage{
 		Resource: "run",

--- a/internal/api/v2/websocket/broadcaster_test.go
+++ b/internal/api/v2/websocket/broadcaster_test.go
@@ -344,6 +344,96 @@ func TestBroadcastGraphRunDeleted(t *testing.T) {
 	}
 }
 
+func TestBroadcastScenarioRunUpdate_IncludesSanitizedClusterJobs(t *testing.T) {
+	hub := NewHub()
+	go hub.Run()
+	defer close(hub.register)
+
+	broadcaster := NewBroadcaster(hub, &mockAuthzChecker{}, nil, "default")
+
+	client := &Client{
+		userID:  "test-user",
+		isAdmin: false,
+		send:    make(chan []byte, 256),
+		subscriptions: map[string]map[string]bool{
+			"run": {"scenario-run-1": true},
+		},
+	}
+
+	hub.register <- client
+	time.Sleep(10 * time.Millisecond)
+
+	now := metav1.Now()
+	scenarioRun := &krknv1alpha1.KrknScenarioRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "scenario-run-1",
+			Namespace: "default",
+		},
+		Status: krknv1alpha1.KrknScenarioRunStatus{
+			Phase:        "Running",
+			TotalTargets: 1,
+			RunningJobs:  1,
+			ClusterJobs: []krknv1alpha1.ClusterJobStatus{
+				{
+					ProviderName:   "provider-1",
+					ClusterName:    "cluster-1",
+					ClusterAPIURL:  "https://secret-api.example.com:6443",
+					JobID:          "job-123",
+					PodName:        "scenario-pod-1",
+					ContainerImage: "quay.io/krkn/scenario:latest",
+					Phase:          "Running",
+					StartTime:      &now,
+				},
+			},
+		},
+	}
+
+	broadcaster.BroadcastScenarioRunUpdate(scenarioRun)
+
+	select {
+	case msg := <-client.send:
+		// Verify clusterJobs is included
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(msg, &raw); err != nil {
+			t.Fatalf("Failed to unmarshal: %v", err)
+		}
+
+		var data map[string]json.RawMessage
+		if err := json.Unmarshal(raw["data"], &data); err != nil {
+			t.Fatalf("Failed to unmarshal data: %v", err)
+		}
+
+		if _, ok := data["clusterJobs"]; !ok {
+			t.Fatal("Expected clusterJobs to be present in broadcast")
+		}
+
+		var jobs []map[string]interface{}
+		if err := json.Unmarshal(data["clusterJobs"], &jobs); err != nil {
+			t.Fatalf("Failed to unmarshal clusterJobs: %v", err)
+		}
+
+		if len(jobs) != 1 {
+			t.Fatalf("Expected 1 job, got %d", len(jobs))
+		}
+
+		job := jobs[0]
+		if job["phase"] != "Running" {
+			t.Errorf("Expected phase 'Running', got '%v'", job["phase"])
+		}
+		if job["jobId"] != "job-123" {
+			t.Errorf("Expected jobId 'job-123', got '%v'", job["jobId"])
+		}
+
+		// ClusterAPIURL must NOT be present (security)
+		if _, ok := job["clusterApiUrl"]; ok {
+			t.Error("ClusterAPIURL must NOT be included in WebSocket broadcast (security)")
+		}
+
+	case <-time.After(100 * time.Millisecond):
+		t.Error("Timeout waiting for broadcast message")
+	}
+}
+
 func TestBroadcastOnlyToSubscribedClients(t *testing.T) {
 	hub := NewHub()
 	go hub.Run()

--- a/internal/api/v2/websocket/response_helpers.go
+++ b/internal/api/v2/websocket/response_helpers.go
@@ -4,9 +4,11 @@ import (
 	"time"
 
 	krknv1alpha1 "github.com/krkn-chaos/krkn-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// buildScenarioRunResponse builds the SAME response as REST API (lightweight, no clusterJobs)
+// buildScenarioRunResponse builds the response with sanitized clusterJobs (no ClusterAPIURL).
+// Used for both lightweight "run" broadcasts and "run" snapshots.
 func buildScenarioRunResponse(run *krknv1alpha1.KrknScenarioRun) ScenarioRunStatusResponse {
 	return ScenarioRunStatusResponse{
 		ScenarioRunName:   run.Name,
@@ -15,7 +17,7 @@ func buildScenarioRunResponse(run *krknv1alpha1.KrknScenarioRun) ScenarioRunStat
 		SuccessfulJobs:    run.Status.SuccessfulJobs,
 		FailedJobs:        run.Status.FailedJobs,
 		RunningJobs:       run.Status.RunningJobs,
-		ClusterJobs:       nil, // Omitted for list view
+		ClusterJobs:       sanitizedClusterJobs(run.Status.ClusterJobs),
 		OwnerUserID:       run.Spec.OwnerUserID,
 		RegistryName:      run.Spec.RegistryName,
 		GraphRunName:      run.Labels["krkn.dev/graph-run"],
@@ -24,7 +26,7 @@ func buildScenarioRunResponse(run *krknv1alpha1.KrknScenarioRun) ScenarioRunStat
 	}
 }
 
-// buildScenarioRunDetailResponse builds FULL response with clusterJobs for detail view
+// buildScenarioRunDetailResponse builds FULL response with sanitized clusterJobs for detail view.
 func buildScenarioRunDetailResponse(run *krknv1alpha1.KrknScenarioRun) ScenarioRunStatusResponse {
 	return ScenarioRunStatusResponse{
 		ScenarioRunName:   run.Name,
@@ -33,13 +35,58 @@ func buildScenarioRunDetailResponse(run *krknv1alpha1.KrknScenarioRun) ScenarioR
 		SuccessfulJobs:    run.Status.SuccessfulJobs,
 		FailedJobs:        run.Status.FailedJobs,
 		RunningJobs:       run.Status.RunningJobs,
-		ClusterJobs:       run.Status.ClusterJobs, // Include full clusterJobs for detail
+		ClusterJobs:       sanitizedClusterJobs(run.Status.ClusterJobs),
 		OwnerUserID:       run.Spec.OwnerUserID,
 		RegistryName:      run.Spec.RegistryName,
 		GraphRunName:      run.Labels["krkn.dev/graph-run"],
 		GraphNodeID:       run.Labels["krkn.dev/graph-node"],
 		CreationTimestamp: run.CreationTimestamp.Format(time.RFC3339),
 	}
+}
+
+// sanitizedClusterJobs returns an interface{}-typed nil when there are no jobs,
+// avoiding the Go typed-nil-in-interface pitfall with omitempty.
+func sanitizedClusterJobs(jobs []krknv1alpha1.ClusterJobStatus) interface{} {
+	converted := convertClusterJobs(jobs)
+	if converted == nil {
+		return nil
+	}
+	return converted
+}
+
+// convertClusterJobs converts raw CRD ClusterJobStatus to sanitized ClusterJobResponse,
+// omitting ClusterAPIURL and LastRetryTime to match the REST API contract.
+func convertClusterJobs(jobs []krknv1alpha1.ClusterJobStatus) []ClusterJobResponse {
+	if len(jobs) == 0 {
+		return nil
+	}
+	result := make([]ClusterJobResponse, len(jobs))
+	for i, job := range jobs {
+		result[i] = ClusterJobResponse{
+			ProviderName:    job.ProviderName,
+			ClusterName:     job.ClusterName,
+			JobID:           job.JobID,
+			PodName:         job.PodName,
+			ContainerImage:  job.ContainerImage,
+			Phase:           job.Phase,
+			StartTime:       convertMetaTime(job.StartTime),
+			CompletionTime:  convertMetaTime(job.CompletionTime),
+			Message:         job.Message,
+			RetryCount:      job.RetryCount,
+			MaxRetries:      job.MaxRetries,
+			CancelRequested: job.CancelRequested,
+			FailureReason:   job.FailureReason,
+		}
+	}
+	return result
+}
+
+func convertMetaTime(t *metav1.Time) *time.Time {
+	if t == nil {
+		return nil
+	}
+	result := t.Time
+	return &result
 }
 
 // buildGraphRunResponse builds the SAME response as REST API

--- a/internal/api/v2/websocket/response_helpers_test.go
+++ b/internal/api/v2/websocket/response_helpers_test.go
@@ -1,0 +1,127 @@
+package websocket
+
+import (
+	"testing"
+
+	krknv1alpha1 "github.com/krkn-chaos/krkn-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestConvertClusterJobs_OmitsClusterAPIURL(t *testing.T) {
+	now := metav1.Now()
+	jobs := []krknv1alpha1.ClusterJobStatus{
+		{
+			ProviderName:    "prov-1",
+			ClusterName:     "cluster-1",
+			ClusterAPIURL:   "https://secret-api.example.com:6443",
+			JobID:           "job-1",
+			PodName:         "pod-1",
+			ContainerImage:  "quay.io/krkn/scenario:latest",
+			Phase:           "Succeeded",
+			StartTime:       &now,
+			CompletionTime:  &now,
+			Message:         "completed",
+			RetryCount:      1,
+			MaxRetries:      3,
+			CancelRequested: false,
+			FailureReason:   "",
+		},
+	}
+
+	result := convertClusterJobs(jobs)
+
+	if len(result) != 1 {
+		t.Fatalf("Expected 1 job, got %d", len(result))
+	}
+
+	r := result[0]
+	if r.ProviderName != "prov-1" {
+		t.Errorf("Expected ProviderName 'prov-1', got '%s'", r.ProviderName)
+	}
+	if r.ClusterName != "cluster-1" {
+		t.Errorf("Expected ClusterName 'cluster-1', got '%s'", r.ClusterName)
+	}
+	if r.JobID != "job-1" {
+		t.Errorf("Expected JobID 'job-1', got '%s'", r.JobID)
+	}
+	if r.Phase != "Succeeded" {
+		t.Errorf("Expected Phase 'Succeeded', got '%s'", r.Phase)
+	}
+	if r.StartTime == nil {
+		t.Error("Expected StartTime to be set")
+	}
+	if r.CompletionTime == nil {
+		t.Error("Expected CompletionTime to be set")
+	}
+	if r.Message != "completed" {
+		t.Errorf("Expected Message 'completed', got '%s'", r.Message)
+	}
+	if r.RetryCount != 1 {
+		t.Errorf("Expected RetryCount 1, got %d", r.RetryCount)
+	}
+}
+
+func TestConvertClusterJobs_NilInput(t *testing.T) {
+	result := convertClusterJobs(nil)
+	if result != nil {
+		t.Errorf("Expected nil for nil input, got %v", result)
+	}
+}
+
+func TestConvertClusterJobs_EmptyInput(t *testing.T) {
+	result := convertClusterJobs([]krknv1alpha1.ClusterJobStatus{})
+	if result != nil {
+		t.Errorf("Expected nil for empty input, got %v", result)
+	}
+}
+
+func TestBuildScenarioRunResponse_IncludesClusterJobs(t *testing.T) {
+	run := &krknv1alpha1.KrknScenarioRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "run-1",
+		},
+		Status: krknv1alpha1.KrknScenarioRunStatus{
+			Phase:        "Running",
+			TotalTargets: 1,
+			RunningJobs:  1,
+			ClusterJobs: []krknv1alpha1.ClusterJobStatus{
+				{
+					ClusterName:   "cluster-1",
+					ClusterAPIURL: "https://secret.example.com",
+					JobID:         "job-1",
+					Phase:         "Running",
+				},
+			},
+		},
+	}
+
+	resp := buildScenarioRunResponse(run)
+
+	jobs, ok := resp.ClusterJobs.([]ClusterJobResponse)
+	if !ok {
+		t.Fatalf("Expected ClusterJobs to be []ClusterJobResponse, got %T", resp.ClusterJobs)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("Expected 1 job, got %d", len(jobs))
+	}
+	if jobs[0].Phase != "Running" {
+		t.Errorf("Expected phase 'Running', got '%s'", jobs[0].Phase)
+	}
+}
+
+func TestBuildScenarioRunResponse_NoClusterJobs(t *testing.T) {
+	run := &krknv1alpha1.KrknScenarioRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "run-1",
+		},
+		Status: krknv1alpha1.KrknScenarioRunStatus{
+			Phase: "Pending",
+		},
+	}
+
+	resp := buildScenarioRunResponse(run)
+
+	if resp.ClusterJobs != nil {
+		t.Errorf("Expected nil ClusterJobs for run with no jobs, got %v", resp.ClusterJobs)
+	}
+}

--- a/internal/api/v2/websocket/types.go
+++ b/internal/api/v2/websocket/types.go
@@ -1,6 +1,8 @@
 package websocket
 
 import (
+	"time"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -72,6 +74,24 @@ type GraphRunSummaryResponse struct {
 	RunningNodes   int `json:"runningNodes"`
 	FailedNodes    int `json:"failedNodes"`
 	PendingNodes   int `json:"pendingNodes"`
+}
+
+// ClusterJobResponse is the sanitized WebSocket response for a cluster job.
+// Mirrors internal/api.ClusterJobStatusResponse — omits ClusterAPIURL for security.
+type ClusterJobResponse struct {
+	ProviderName    string     `json:"providerName"`
+	ClusterName     string     `json:"clusterName"`
+	JobID           string     `json:"jobId"`
+	PodName         string     `json:"podName,omitempty"`
+	ContainerImage  string     `json:"containerImage,omitempty"`
+	Phase           string     `json:"phase"`
+	StartTime       *time.Time `json:"startTime,omitempty"`
+	CompletionTime  *time.Time `json:"completionTime,omitempty"`
+	Message         string     `json:"message,omitempty"`
+	RetryCount      int        `json:"retryCount,omitempty"`
+	MaxRetries      int        `json:"maxRetries,omitempty"`
+	CancelRequested bool       `json:"cancelRequested,omitempty"`
+	FailureReason   string     `json:"failureReason,omitempty"`
 }
 
 // ServerMessage is sent from server to client

--- a/internal/controller/krknscenariorun_controller.go
+++ b/internal/controller/krknscenariorun_controller.go
@@ -386,8 +386,9 @@ func (r *KrknScenarioRunReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			"runningJobs", scenarioRun.Status.RunningJobs)
 	}
 
-	// Requeue if run is still active (Running includes pending jobs via calculateOverallStatus)
-	if scenarioRun.Status.Phase == "Running" || scenarioRun.Status.Phase == "Pending" {
+	// Requeue if run is still active. Phase "Running" covers both running and pending
+	// jobs (calculateOverallStatus sets Running when pendingJobs > 0).
+	if scenarioRun.Status.Phase == "Running" {
 		logger.V(1).Info("requeuing because run still active",
 			"scenarioRun", scenarioRun.Name,
 			"phase", scenarioRun.Status.Phase,

--- a/internal/controller/krknscenariorun_controller.go
+++ b/internal/controller/krknscenariorun_controller.go
@@ -186,6 +186,7 @@ func (r *KrknScenarioRunReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			logger.Error(err, "failed to initialize status")
 			return ctrl.Result{}, err
 		}
+		return ctrl.Result{Requeue: true}, nil
 	}
 
 	// Snapshot status BEFORE any job creation so that appended failure entries are
@@ -385,10 +386,11 @@ func (r *KrknScenarioRunReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			"runningJobs", scenarioRun.Status.RunningJobs)
 	}
 
-	// Requeue if jobs still running
-	if scenarioRun.Status.RunningJobs > 0 {
-		logger.V(1).Info("requeuing because jobs still running",
+	// Requeue if run is still active (Running includes pending jobs via calculateOverallStatus)
+	if scenarioRun.Status.Phase == "Running" || scenarioRun.Status.Phase == "Pending" {
+		logger.V(1).Info("requeuing because run still active",
 			"scenarioRun", scenarioRun.Name,
+			"phase", scenarioRun.Status.Phase,
 			"runningJobs", scenarioRun.Status.RunningJobs)
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}


### PR DESCRIPTION
## Summary
- **Root cause**: the lightweight "run" WebSocket broadcast sent `ClusterJobs: nil`, forcing the console to rely on REST polling every 5s. When a run reached a terminal phase (Succeeded/Failed), the polling stopped before fetching the final job states — leaving clusterJobs stuck at "Running" in the UI
- Include `ClusterJobs` in the lightweight broadcast so job phases arrive in real-time via WebSocket
- Requeue based on run `Phase` (Running/Pending) instead of `RunningJobs` count, ensuring Pending-only runs are also monitored
- Return after status initialization to avoid two `Status().Update()` calls in the same reconcile (prevents resourceVersion conflicts)

## Test plan
- [x] All unit tests pass (`go test ./...` — only e2e skipped, requires cluster)
- [ ] Manual: create a ScenarioRun, expand in console list view, verify job phases reach Succeeded/Failed
- [ ] Verify WebSocket messages now include `clusterJobs` array in lightweight "run" broadcasts

🤖 Generated with [Claude Code](https://claude.com/claude-code)