### PR TITLE
feat(api): add server-side pagination for unified jobs endpoint

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,6 +25,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/go-logr/logr"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -412,7 +414,8 @@ func (c *ConfigStoreInitializer) Start(ctx context.Context) error {
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Info("config configmap not found, kvstore will be initialized when ConfigMap is created")
-			// Not an error - ConfigMap might be created later by controllers
+			// Still apply env var overrides and defaults
+			c.applyPaginationDefaults(kvstore.Get(), logger)
 			return nil
 		}
 		logger.Error(err, "failed to get config configmap")
@@ -428,6 +431,9 @@ func (c *ConfigStoreInitializer) Start(ctx context.Context) error {
 		return nil
 	}
 
+	// Apply env var overrides and defaults for pagination
+	c.applyPaginationDefaults(store, logger)
+
 	// Log what was loaded
 	snapshot := store.Snapshot()
 	logger.Info("kvstore initialized from configmap",
@@ -436,6 +442,26 @@ func (c *ConfigStoreInitializer) Start(ctx context.Context) error {
 		"keys", len(snapshot))
 
 	return nil
+}
+
+// applyPaginationDefaults sets pagination configuration with env var override and defaults.
+func (c *ConfigStoreInitializer) applyPaginationDefaults(store *kvstore.Store, logger logr.Logger) {
+	const (
+		key        = "jobs.defaultPageSize"
+		envVar     = "KRKN_JOBS_DEFAULT_PAGE_SIZE"
+		defaultVal = "20"
+	)
+
+	if envVal := os.Getenv(envVar); envVal != "" {
+		store.SetValue(key, envVal)
+		logger.Info("pagination default page size set from env var", "env", envVar, "value", envVal)
+		return
+	}
+
+	if _, exists := store.GetValue(key); !exists {
+		store.SetValue(key, defaultVal)
+		logger.Info("pagination default page size set to default", "value", defaultVal)
+	}
 }
 
 // NeedLeaderElection implements manager.LeaderElectionRunnable

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -112,9 +112,10 @@ func TestConfigStoreInitializer_Start_ConfigMapNotFound(t *testing.T) {
 		t.Errorf("Expected no error when ConfigMap not found, got %v", err)
 	}
 
-	// kvstore should be empty
-	if len(store.Snapshot()) > 0 {
-		t.Errorf("Expected empty kvstore, got %d keys", len(store.Snapshot()))
+	// kvstore should only contain pagination defaults
+	snapshot = store.Snapshot()
+	if val, ok := snapshot["jobs.defaultPageSize"]; !ok || val != "20" {
+		t.Errorf("Expected jobs.defaultPageSize=20, got %v", snapshot)
 	}
 }
 

--- a/internal/api/jobs_handlers.go
+++ b/internal/api/jobs_handlers.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"net/http"
+	"sort"
+	"strconv"
+
+	krknv1alpha1 "github.com/krkn-chaos/krkn-operator/api/v1alpha1"
+	kvstore "github.com/krkn-chaos/krkn-operator/pkg/configstore"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const defaultPageSize = 20
+
+// getDefaultPageSize reads the default page size from the configstore.
+func getDefaultPageSize() int {
+	if val, ok := kvstore.Get().GetValue("jobs.defaultPageSize"); ok {
+		if n, err := strconv.Atoi(val); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultPageSize
+}
+
+// ListJobs handles GET /api/v2/jobs
+// Returns a unified, paginated list of standalone ScenarioRuns and GraphRuns sorted by creation time (newest first).
+//
+// @Summary List all jobs (unified view)
+// @Description Returns a merged list of standalone ScenarioRuns and GraphRuns, sorted by creation time descending
+// @Tags jobs
+// @Produce json
+// @Param page query int false "Page number (1-based). Omit for all results."
+// @Param limit query int false "Items per page. Defaults to jobs.defaultPageSize from ConfigMap."
+// @Success 200 {object} UnifiedJobsResponse "Paginated list of jobs"
+// @Failure 500 {object} ErrorResponse "Internal server error"
+// @Security BearerAuth
+// @Router /v2/jobs [get]
+func (h *Handler) ListJobs(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	logger := log.FromContext(ctx).WithName("list-jobs")
+
+	// List ScenarioRuns
+	var scenarioRuns krknv1alpha1.KrknScenarioRunList
+	if err := h.client.List(ctx, &scenarioRuns, client.InNamespace(h.namespace)); err != nil {
+		logger.Error(err, "Failed to list scenario runs")
+		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
+			Error:   "internal_error",
+			Message: "Failed to list scenario runs",
+		})
+		return
+	}
+
+	// List GraphRuns
+	var graphRuns krknv1alpha1.KrknGraphRunList
+	if err := h.client.List(ctx, &graphRuns, client.InNamespace(h.namespace)); err != nil {
+		logger.Error(err, "Failed to list graph runs")
+		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
+			Error:   "internal_error",
+			Message: "Failed to list graph runs",
+		})
+		return
+	}
+
+	// Apply group permission filters
+	filteredScenarioRuns := h.FilterScenarioRunsByGroupPermission(scenarioRuns.Items, ctx)
+	filteredGraphRuns := h.FilterGraphRunsByGroupPermission(graphRuns.Items, ctx)
+
+	// Build unified list
+	jobs := BuildUnifiedJobList(filteredScenarioRuns, filteredGraphRuns)
+
+	// Parse pagination params
+	page, limit := ParsePaginationParams(r, getDefaultPageSize())
+
+	var response UnifiedJobsResponse
+	if page == 0 {
+		// No pagination requested — return all items
+		response = UnifiedJobsResponse{
+			Jobs: jobs,
+			Pagination: PaginationMeta{
+				Total: len(jobs),
+			},
+		}
+	} else {
+		paginated, meta := PaginateSlice(jobs, page, limit)
+		response = UnifiedJobsResponse{
+			Jobs:       paginated,
+			Pagination: meta,
+		}
+	}
+
+	logger.Info("Listed jobs", "total", response.Pagination.Total, "page", response.Pagination.Page, "returned", len(response.Jobs))
+	writeJSON(w, http.StatusOK, response)
+}
+
+// BuildUnifiedJobList merges standalone ScenarioRuns and GraphRuns into a single
+// sorted list of UnifiedJobItems (newest first).
+func BuildUnifiedJobList(scenarioRuns []krknv1alpha1.KrknScenarioRun, graphRuns []krknv1alpha1.KrknGraphRun) []UnifiedJobItem {
+	jobs := make([]UnifiedJobItem, 0, len(scenarioRuns)+len(graphRuns))
+
+	for i := range scenarioRuns {
+		sr := &scenarioRuns[i]
+		// Skip ScenarioRuns that are part of a GraphRun
+		if sr.Labels["krkn.dev/graph-run"] != "" {
+			continue
+		}
+
+		item := ScenarioRunListItem{
+			ScenarioRunName:  sr.Name,
+			ScenarioName:     sr.Spec.ScenarioName,
+			Phase:            sr.Status.Phase,
+			TotalTargets:     sr.Status.TotalTargets,
+			SuccessfulJobs:   sr.Status.SuccessfulJobs,
+			FailedJobs:       sr.Status.FailedJobs,
+			RunningJobs:      sr.Status.RunningJobs,
+			CreatedAt:        sr.CreationTimestamp.Time,
+			OwnerUserID:      sr.Spec.OwnerUserID,
+			GraphRunName:     sr.Labels["krkn.dev/graph-run"],
+			GraphNodeID:      sr.Labels["krkn.dev/graph-node"],
+			CustomRunName:    sr.Spec.CustomRunName,
+			ResiliencyScore:  averageResiliencyScore(sr.Status.ResiliencyScores),
+			ResiliencyScores: convertClusterResiliencyScores(sr.Status.ResiliencyScores),
+		}
+		jobs = append(jobs, UnifiedJobItem{
+			Type:        "scenarioRun",
+			Name:        sr.Name,
+			CreatedAt:   sr.CreationTimestamp.Time,
+			ScenarioRun: &item,
+		})
+	}
+
+	for i := range graphRuns {
+		gr := &graphRuns[i]
+		item := GraphRunListItem{
+			Name:              gr.Name,
+			Namespace:         gr.Namespace,
+			CreationTimestamp: gr.CreationTimestamp.Time,
+			Phase:             gr.Status.Phase,
+			OwnerUserID:       gr.Spec.OwnerUserID,
+			TargetRequestID:   gr.Spec.TargetRequestID,
+			Summary: GraphRunSummaryResponse{
+				TotalNodes:     gr.Status.Summary.TotalNodes,
+				CompletedNodes: gr.Status.Summary.CompletedNodes,
+				RunningNodes:   gr.Status.Summary.RunningNodes,
+				FailedNodes:    gr.Status.Summary.FailedNodes,
+				PendingNodes:   gr.Status.Summary.PendingNodes,
+			},
+			StartTime:               gr.Status.StartTime,
+			CompletionTime:          gr.Status.CompletionTime,
+			ResiliencyScoreEnabled:  gr.Spec.ResiliencyScoreEnabled,
+			ResiliencyScoreBaseline: gr.Spec.ResiliencyScoreBaseline,
+			ResiliencyScores:        convertGraphClusterScores(gr.Status.ResiliencyScores),
+		}
+		jobs = append(jobs, UnifiedJobItem{
+			Type:      "graphRun",
+			Name:      gr.Name,
+			CreatedAt: gr.CreationTimestamp.Time,
+			GraphRun:  &item,
+		})
+	}
+
+	// Sort by creation time descending (newest first)
+	sort.Slice(jobs, func(i, j int) bool {
+		return jobs[i].CreatedAt.After(jobs[j].CreatedAt)
+	})
+
+	return jobs
+}

--- a/internal/api/jobs_handlers_test.go
+++ b/internal/api/jobs_handlers_test.go
@@ -1,0 +1,361 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	krknv1alpha1 "github.com/krkn-chaos/krkn-operator/api/v1alpha1"
+	"github.com/krkn-chaos/krkn-operator/pkg/auth"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func makeScenarioRun(name string, createdAt time.Time) *krknv1alpha1.KrknScenarioRun {
+	return &krknv1alpha1.KrknScenarioRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(createdAt),
+			Labels:            map[string]string{},
+		},
+		Spec: krknv1alpha1.KrknScenarioRunSpec{
+			ScenarioName: "test-scenario",
+			OwnerUserID:  "user@example.com",
+		},
+		Status: krknv1alpha1.KrknScenarioRunStatus{
+			Phase: "Running",
+		},
+	}
+}
+
+func makeGraphRun(name string, createdAt time.Time) *krknv1alpha1.KrknGraphRun {
+	return &krknv1alpha1.KrknGraphRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(createdAt),
+		},
+		Spec: krknv1alpha1.KrknGraphRunSpec{
+			OwnerUserID: "user@example.com",
+		},
+		Status: krknv1alpha1.KrknGraphRunStatus{
+			Phase: "Running",
+		},
+	}
+}
+
+func TestListJobs_NoPagination(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = krknv1alpha1.AddToScheme(scheme)
+
+	now := time.Now()
+	sr1 := makeScenarioRun("sr-1", now.Add(-2*time.Hour))
+	sr2 := makeScenarioRun("sr-2", now.Add(-1*time.Hour))
+	gr1 := makeGraphRun("gr-1", now)
+
+	fakeClient := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(sr1, sr2, gr1).
+		Build()
+	fakeClientset := fake.NewSimpleClientset()
+	handler := NewTestHandler(fakeClient, fakeClientset, "default", "localhost:50051")
+
+	req := httptest.NewRequest("GET", "/api/v2/jobs", nil)
+	ctx := context.WithValue(req.Context(), auth.UserClaimsKey, &auth.Claims{
+		UserID: "admin@example.com",
+		Role:   "admin",
+	})
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.ListJobs(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var response UnifiedJobsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if len(response.Jobs) != 3 {
+		t.Errorf("expected 3 jobs, got %d", len(response.Jobs))
+	}
+	if response.Pagination.Total != 3 {
+		t.Errorf("expected total 3, got %d", response.Pagination.Total)
+	}
+
+	// Verify sorted by creation time DESC (newest first)
+	if response.Jobs[0].Name != "gr-1" {
+		t.Errorf("expected first item to be gr-1 (newest), got %s", response.Jobs[0].Name)
+	}
+	if response.Jobs[2].Name != "sr-1" {
+		t.Errorf("expected last item to be sr-1 (oldest), got %s", response.Jobs[2].Name)
+	}
+}
+
+func TestListJobs_Paginated(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = krknv1alpha1.AddToScheme(scheme)
+
+	now := time.Now()
+	sr1 := makeScenarioRun("sr-1", now.Add(-5*time.Hour))
+	sr2 := makeScenarioRun("sr-2", now.Add(-4*time.Hour))
+	sr3 := makeScenarioRun("sr-3", now.Add(-3*time.Hour))
+	gr1 := makeGraphRun("gr-1", now.Add(-2*time.Hour))
+	gr2 := makeGraphRun("gr-2", now.Add(-1*time.Hour))
+
+	fakeClient := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(sr1, sr2, sr3, gr1, gr2).
+		Build()
+	fakeClientset := fake.NewSimpleClientset()
+	handler := NewTestHandler(fakeClient, fakeClientset, "default", "localhost:50051")
+
+	// Page 1 with limit 2
+	req := httptest.NewRequest("GET", "/api/v2/jobs?page=1&limit=2", nil)
+	ctx := context.WithValue(req.Context(), auth.UserClaimsKey, &auth.Claims{
+		UserID: "admin@example.com",
+		Role:   "admin",
+	})
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.ListJobs(w, req)
+
+	var page1 UnifiedJobsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &page1); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if len(page1.Jobs) != 2 {
+		t.Errorf("expected 2 items on page 1, got %d", len(page1.Jobs))
+	}
+	if page1.Pagination.Total != 5 {
+		t.Errorf("expected total 5, got %d", page1.Pagination.Total)
+	}
+	if page1.Pagination.TotalPages != 3 {
+		t.Errorf("expected 3 pages, got %d", page1.Pagination.TotalPages)
+	}
+	if page1.Pagination.Page != 1 {
+		t.Errorf("expected page 1, got %d", page1.Pagination.Page)
+	}
+
+	// Page 3 (last page with 1 item)
+	req2 := httptest.NewRequest("GET", "/api/v2/jobs?page=3&limit=2", nil)
+	ctx2 := context.WithValue(req2.Context(), auth.UserClaimsKey, &auth.Claims{
+		UserID: "admin@example.com",
+		Role:   "admin",
+	})
+	req2 = req2.WithContext(ctx2)
+	w2 := httptest.NewRecorder()
+
+	handler.ListJobs(w2, req2)
+
+	var page3 UnifiedJobsResponse
+	if err := json.Unmarshal(w2.Body.Bytes(), &page3); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if len(page3.Jobs) != 1 {
+		t.Errorf("expected 1 item on last page, got %d", len(page3.Jobs))
+	}
+}
+
+func TestListJobs_Empty(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = krknv1alpha1.AddToScheme(scheme)
+
+	fakeClient := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+	fakeClientset := fake.NewSimpleClientset()
+	handler := NewTestHandler(fakeClient, fakeClientset, "default", "localhost:50051")
+
+	req := httptest.NewRequest("GET", "/api/v2/jobs?page=1&limit=20", nil)
+	ctx := context.WithValue(req.Context(), auth.UserClaimsKey, &auth.Claims{
+		UserID: "admin@example.com",
+		Role:   "admin",
+	})
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.ListJobs(w, req)
+
+	var response UnifiedJobsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if len(response.Jobs) != 0 {
+		t.Errorf("expected 0 jobs, got %d", len(response.Jobs))
+	}
+	if response.Pagination.Total != 0 {
+		t.Errorf("expected total 0, got %d", response.Pagination.Total)
+	}
+}
+
+func TestListJobs_SkipsGraphRunChildren(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = krknv1alpha1.AddToScheme(scheme)
+
+	now := time.Now()
+	standalone := makeScenarioRun("standalone-run", now)
+
+	child := makeScenarioRun("graph-child-run", now.Add(-time.Hour))
+	child.Labels["krkn.dev/graph-run"] = "parent-graph"
+
+	gr := makeGraphRun("parent-graph", now.Add(-30*time.Minute))
+
+	fakeClient := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(standalone, child, gr).
+		Build()
+	fakeClientset := fake.NewSimpleClientset()
+	handler := NewTestHandler(fakeClient, fakeClientset, "default", "localhost:50051")
+
+	req := httptest.NewRequest("GET", "/api/v2/jobs", nil)
+	ctx := context.WithValue(req.Context(), auth.UserClaimsKey, &auth.Claims{
+		UserID: "admin@example.com",
+		Role:   "admin",
+	})
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.ListJobs(w, req)
+
+	var response UnifiedJobsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	// Should only have standalone run + graph run, not the graph child
+	if len(response.Jobs) != 2 {
+		t.Errorf("expected 2 jobs (standalone + graph), got %d", len(response.Jobs))
+	}
+
+	for _, job := range response.Jobs {
+		if job.Name == "graph-child-run" {
+			t.Error("graph-run child should not appear in unified list")
+		}
+	}
+}
+
+func TestListJobs_TypeDiscriminator(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = krknv1alpha1.AddToScheme(scheme)
+
+	now := time.Now()
+	sr := makeScenarioRun("sr-1", now)
+	gr := makeGraphRun("gr-1", now.Add(-time.Hour))
+
+	fakeClient := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(sr, gr).
+		Build()
+	fakeClientset := fake.NewSimpleClientset()
+	handler := NewTestHandler(fakeClient, fakeClientset, "default", "localhost:50051")
+
+	req := httptest.NewRequest("GET", "/api/v2/jobs", nil)
+	ctx := context.WithValue(req.Context(), auth.UserClaimsKey, &auth.Claims{
+		UserID: "admin@example.com",
+		Role:   "admin",
+	})
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.ListJobs(w, req)
+
+	var response UnifiedJobsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	for _, job := range response.Jobs {
+		switch job.Type {
+		case "scenarioRun":
+			if job.ScenarioRun == nil {
+				t.Error("scenarioRun type should have ScenarioRun field set")
+			}
+			if job.GraphRun != nil {
+				t.Error("scenarioRun type should not have GraphRun field set")
+			}
+		case "graphRun":
+			if job.GraphRun == nil {
+				t.Error("graphRun type should have GraphRun field set")
+			}
+			if job.ScenarioRun != nil {
+				t.Error("graphRun type should not have ScenarioRun field set")
+			}
+		default:
+			t.Errorf("unexpected type: %s", job.Type)
+		}
+	}
+}
+
+func TestBuildUnifiedJobList_SortOrder(t *testing.T) {
+	now := time.Now()
+
+	scenarioRuns := []krknv1alpha1.KrknScenarioRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "sr-oldest",
+				CreationTimestamp: metav1.NewTime(now.Add(-3 * time.Hour)),
+				Labels:            map[string]string{},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "sr-newest",
+				CreationTimestamp: metav1.NewTime(now),
+				Labels:            map[string]string{},
+			},
+		},
+	}
+
+	graphRuns := []krknv1alpha1.KrknGraphRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "gr-middle",
+				CreationTimestamp: metav1.NewTime(now.Add(-1 * time.Hour)),
+			},
+		},
+	}
+
+	jobs := BuildUnifiedJobList(scenarioRuns, graphRuns)
+
+	if len(jobs) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(jobs))
+	}
+
+	// Newest first
+	expectedOrder := []string{"sr-newest", "gr-middle", "sr-oldest"}
+	for i, expected := range expectedOrder {
+		if jobs[i].Name != expected {
+			t.Errorf("position %d: expected %s, got %s", i, expected, jobs[i].Name)
+		}
+	}
+}

--- a/internal/api/jobs_handlers_test.go
+++ b/internal/api/jobs_handlers_test.go
@@ -218,6 +218,46 @@ func TestListJobs_Empty(t *testing.T) {
 	}
 }
 
+func TestListJobs_LimitOnlyReturnsAll(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = krknv1alpha1.AddToScheme(scheme)
+
+	now := time.Now()
+	sr1 := makeScenarioRun("sr-1", now.Add(-2*time.Hour))
+	sr2 := makeScenarioRun("sr-2", now.Add(-1*time.Hour))
+	gr1 := makeGraphRun("gr-1", now)
+
+	fakeClient := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(sr1, sr2, gr1).
+		Build()
+	fakeClientset := fake.NewSimpleClientset()
+	handler := NewTestHandler(fakeClient, fakeClientset, "default", "localhost:50051")
+
+	// Only limit param, no page → should return ALL items (not truncated to page 1)
+	req := httptest.NewRequest("GET", "/api/v2/jobs?limit=2", nil)
+	ctx := context.WithValue(req.Context(), auth.UserClaimsKey, &auth.Claims{
+		UserID: "admin@example.com",
+		Role:   "admin",
+	})
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.ListJobs(w, req)
+
+	var response UnifiedJobsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if len(response.Jobs) != 3 {
+		t.Errorf("expected all 3 jobs when only limit param provided, got %d", len(response.Jobs))
+	}
+	if response.Pagination.Page != 0 {
+		t.Errorf("expected page=0 (unpaginated), got %d", response.Pagination.Page)
+	}
+}
+
 func TestListJobs_SkipsGraphRunChildren(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = krknv1alpha1.AddToScheme(scheme)

--- a/internal/api/pagination.go
+++ b/internal/api/pagination.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"math"
+	"net/http"
+	"strconv"
+)
+
+// PaginateSlice returns the items for the given page and pagination metadata.
+// page is 1-based. If page is beyond the total, an empty slice is returned.
+func PaginateSlice[T any](items []T, page, limit int) ([]T, PaginationMeta) {
+	total := len(items)
+	totalPages := 0
+	if limit > 0 {
+		totalPages = int(math.Ceil(float64(total) / float64(limit)))
+	}
+
+	meta := PaginationMeta{
+		Page:       page,
+		Limit:      limit,
+		Total:      total,
+		TotalPages: totalPages,
+	}
+
+	if limit <= 0 || page <= 0 {
+		return items, meta
+	}
+
+	offset := (page - 1) * limit
+	if offset >= total {
+		return []T{}, meta
+	}
+
+	end := offset + limit
+	if end > total {
+		end = total
+	}
+
+	return items[offset:end], meta
+}
+
+// ParsePaginationParams parses page and limit query parameters from the request.
+// Returns (0, 0) if no pagination params are present (meaning "return all").
+func ParsePaginationParams(r *http.Request, defaultLimit int) (page, limit int) {
+	pageStr := r.URL.Query().Get("page")
+	limitStr := r.URL.Query().Get("limit")
+
+	if pageStr == "" && limitStr == "" {
+		return 0, 0
+	}
+
+	page = 1
+	limit = defaultLimit
+
+	if pageStr != "" {
+		if p, err := strconv.Atoi(pageStr); err == nil && p > 0 {
+			page = p
+		}
+	}
+
+	if limitStr != "" {
+		if l, err := strconv.Atoi(limitStr); err == nil && l > 0 {
+			limit = l
+		}
+	}
+
+	return page, limit
+}

--- a/internal/api/pagination.go
+++ b/internal/api/pagination.go
@@ -55,29 +55,32 @@ func PaginateSlice[T any](items []T, page, limit int) ([]T, PaginationMeta) {
 	return items[offset:end], meta
 }
 
+const maxPageSize = 500
+
 // ParsePaginationParams parses page and limit query parameters from the request.
-// Returns (0, 0) if no pagination params are present (meaning "return all").
+// Returns (0, 0) if the page param is absent (meaning "return all").
+// The limit param is only read when page is present.
 func ParsePaginationParams(r *http.Request, defaultLimit int) (page, limit int) {
 	pageStr := r.URL.Query().Get("page")
-	limitStr := r.URL.Query().Get("limit")
-
-	if pageStr == "" && limitStr == "" {
+	if pageStr == "" {
 		return 0, 0
 	}
 
 	page = 1
 	limit = defaultLimit
 
-	if pageStr != "" {
-		if p, err := strconv.Atoi(pageStr); err == nil && p > 0 {
-			page = p
-		}
+	if p, err := strconv.Atoi(pageStr); err == nil && p > 0 {
+		page = p
 	}
 
-	if limitStr != "" {
+	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
 		if l, err := strconv.Atoi(limitStr); err == nil && l > 0 {
 			limit = l
 		}
+	}
+
+	if limit > maxPageSize {
+		limit = maxPageSize
 	}
 
 	return page, limit

--- a/internal/api/pagination_test.go
+++ b/internal/api/pagination_test.go
@@ -17,159 +17,78 @@ limitations under the License.
 package api
 
 import (
+	"fmt"
 	"net/http/httptest"
 	"testing"
 )
 
-func TestPaginateSlice_FirstPage(t *testing.T) {
-	items := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
-	result, meta := PaginateSlice(items, 1, 3)
+func TestPaginateSlice(t *testing.T) {
+	tests := []struct {
+		name          string
+		items         []int
+		page          int
+		limit         int
+		wantLen       int
+		wantFirst     int // -1 to skip
+		wantTotal     int
+		wantTotalPgs  int
+	}{
+		{"FirstPage", []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 1, 3, 3, 1, 10, 4},
+		{"MiddlePage", []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 2, 3, 3, 4, 10, 4},
+		{"LastPage", []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 4, 3, 1, 10, 10, 4},
+		{"BeyondTotal", []int{1, 2, 3}, 5, 3, 0, -1, 3, 1},
+		{"Empty", []int{}, 1, 10, 0, -1, 0, 0},
+		{"ZeroLimit", []int{1, 2, 3}, 1, 0, 3, 1, 3, 0},
+		{"ExactFit", []int{1, 2, 3, 4, 5, 6}, 2, 3, 3, 4, 6, 2},
+	}
 
-	if len(result) != 3 {
-		t.Errorf("expected 3 items, got %d", len(result))
-	}
-	if result[0] != 1 || result[1] != 2 || result[2] != 3 {
-		t.Errorf("expected [1,2,3], got %v", result)
-	}
-	if meta.Total != 10 {
-		t.Errorf("expected total 10, got %d", meta.Total)
-	}
-	if meta.TotalPages != 4 {
-		t.Errorf("expected 4 pages, got %d", meta.TotalPages)
-	}
-	if meta.Page != 1 {
-		t.Errorf("expected page 1, got %d", meta.Page)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, meta := PaginateSlice(tc.items, tc.page, tc.limit)
+			if len(result) != tc.wantLen {
+				t.Errorf("len = %d, want %d", len(result), tc.wantLen)
+			}
+			if tc.wantFirst >= 0 && len(result) > 0 && result[0] != tc.wantFirst {
+				t.Errorf("first = %d, want %d", result[0], tc.wantFirst)
+			}
+			if meta.Total != tc.wantTotal {
+				t.Errorf("total = %d, want %d", meta.Total, tc.wantTotal)
+			}
+			if meta.TotalPages != tc.wantTotalPgs {
+				t.Errorf("totalPages = %d, want %d", meta.TotalPages, tc.wantTotalPgs)
+			}
+		})
 	}
 }
 
-func TestPaginateSlice_MiddlePage(t *testing.T) {
-	items := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
-	result, meta := PaginateSlice(items, 2, 3)
-
-	if len(result) != 3 {
-		t.Errorf("expected 3 items, got %d", len(result))
+func TestParsePaginationParams(t *testing.T) {
+	tests := []struct {
+		name      string
+		query     string
+		defLimit  int
+		wantPage  int
+		wantLimit int
+	}{
+		{"NoParams", "/api/v2/jobs", 20, 0, 0},
+		{"PageOnly", "/api/v2/jobs?page=3", 20, 3, 20},
+		{"PageAndLimit", "/api/v2/jobs?page=2&limit=50", 20, 2, 50},
+		{"InvalidPage", "/api/v2/jobs?page=abc", 20, 1, 20},
+		{"NegativePage", "/api/v2/jobs?page=-1", 20, 1, 20},
+		{"LimitOnly_ReturnsAll", "/api/v2/jobs?limit=5", 20, 0, 0},
+		{"LimitAboveMax", fmt.Sprintf("/api/v2/jobs?page=1&limit=%d", maxPageSize+100), 20, 1, maxPageSize},
 	}
-	if result[0] != 4 || result[1] != 5 || result[2] != 6 {
-		t.Errorf("expected [4,5,6], got %v", result)
-	}
-	if meta.Total != 10 {
-		t.Errorf("expected total 10, got %d", meta.Total)
-	}
-}
 
-func TestPaginateSlice_LastPage(t *testing.T) {
-	items := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
-	result, meta := PaginateSlice(items, 4, 3)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tc.query, nil)
+			page, limit := ParsePaginationParams(req, tc.defLimit)
 
-	if len(result) != 1 {
-		t.Errorf("expected 1 item on last page, got %d", len(result))
-	}
-	if result[0] != 10 {
-		t.Errorf("expected [10], got %v", result)
-	}
-	if meta.TotalPages != 4 {
-		t.Errorf("expected 4 pages, got %d", meta.TotalPages)
-	}
-}
-
-func TestPaginateSlice_BeyondTotal(t *testing.T) {
-	items := []int{1, 2, 3}
-	result, meta := PaginateSlice(items, 5, 3)
-
-	if len(result) != 0 {
-		t.Errorf("expected empty slice for page beyond total, got %d items", len(result))
-	}
-	if meta.Total != 3 {
-		t.Errorf("expected total 3, got %d", meta.Total)
-	}
-}
-
-func TestPaginateSlice_Empty(t *testing.T) {
-	items := []int{}
-	result, meta := PaginateSlice(items, 1, 10)
-
-	if len(result) != 0 {
-		t.Errorf("expected empty result, got %d items", len(result))
-	}
-	if meta.Total != 0 {
-		t.Errorf("expected total 0, got %d", meta.Total)
-	}
-	if meta.TotalPages != 0 {
-		t.Errorf("expected 0 pages, got %d", meta.TotalPages)
-	}
-}
-
-func TestPaginateSlice_ZeroLimit(t *testing.T) {
-	items := []int{1, 2, 3}
-	result, _ := PaginateSlice(items, 1, 0)
-
-	if len(result) != 3 {
-		t.Errorf("expected all items with zero limit, got %d", len(result))
-	}
-}
-
-func TestPaginateSlice_ExactFit(t *testing.T) {
-	items := []int{1, 2, 3, 4, 5, 6}
-	result, meta := PaginateSlice(items, 2, 3)
-
-	if len(result) != 3 {
-		t.Errorf("expected 3 items, got %d", len(result))
-	}
-	if meta.TotalPages != 2 {
-		t.Errorf("expected 2 pages for exact fit, got %d", meta.TotalPages)
-	}
-}
-
-func TestParsePaginationParams_NoPagination(t *testing.T) {
-	req := httptest.NewRequest("GET", "/api/v2/jobs", nil)
-	page, limit := ParsePaginationParams(req, 20)
-
-	if page != 0 || limit != 0 {
-		t.Errorf("expected (0,0) when no params, got (%d,%d)", page, limit)
-	}
-}
-
-func TestParsePaginationParams_WithPage(t *testing.T) {
-	req := httptest.NewRequest("GET", "/api/v2/jobs?page=3", nil)
-	page, limit := ParsePaginationParams(req, 20)
-
-	if page != 3 {
-		t.Errorf("expected page 3, got %d", page)
-	}
-	if limit != 20 {
-		t.Errorf("expected default limit 20, got %d", limit)
-	}
-}
-
-func TestParsePaginationParams_WithBoth(t *testing.T) {
-	req := httptest.NewRequest("GET", "/api/v2/jobs?page=2&limit=50", nil)
-	page, limit := ParsePaginationParams(req, 20)
-
-	if page != 2 {
-		t.Errorf("expected page 2, got %d", page)
-	}
-	if limit != 50 {
-		t.Errorf("expected limit 50, got %d", limit)
-	}
-}
-
-func TestParsePaginationParams_InvalidPage(t *testing.T) {
-	req := httptest.NewRequest("GET", "/api/v2/jobs?page=abc", nil)
-	page, limit := ParsePaginationParams(req, 20)
-
-	if page != 1 {
-		t.Errorf("expected default page 1 for invalid input, got %d", page)
-	}
-	if limit != 20 {
-		t.Errorf("expected default limit 20, got %d", limit)
-	}
-}
-
-func TestParsePaginationParams_NegativePage(t *testing.T) {
-	req := httptest.NewRequest("GET", "/api/v2/jobs?page=-1", nil)
-	page, _ := ParsePaginationParams(req, 20)
-
-	if page != 1 {
-		t.Errorf("expected default page 1 for negative input, got %d", page)
+			if page != tc.wantPage {
+				t.Errorf("page = %d, want %d", page, tc.wantPage)
+			}
+			if limit != tc.wantLimit {
+				t.Errorf("limit = %d, want %d", limit, tc.wantLimit)
+			}
+		})
 	}
 }

--- a/internal/api/pagination_test.go
+++ b/internal/api/pagination_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPaginateSlice_FirstPage(t *testing.T) {
+	items := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	result, meta := PaginateSlice(items, 1, 3)
+
+	if len(result) != 3 {
+		t.Errorf("expected 3 items, got %d", len(result))
+	}
+	if result[0] != 1 || result[1] != 2 || result[2] != 3 {
+		t.Errorf("expected [1,2,3], got %v", result)
+	}
+	if meta.Total != 10 {
+		t.Errorf("expected total 10, got %d", meta.Total)
+	}
+	if meta.TotalPages != 4 {
+		t.Errorf("expected 4 pages, got %d", meta.TotalPages)
+	}
+	if meta.Page != 1 {
+		t.Errorf("expected page 1, got %d", meta.Page)
+	}
+}
+
+func TestPaginateSlice_MiddlePage(t *testing.T) {
+	items := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	result, meta := PaginateSlice(items, 2, 3)
+
+	if len(result) != 3 {
+		t.Errorf("expected 3 items, got %d", len(result))
+	}
+	if result[0] != 4 || result[1] != 5 || result[2] != 6 {
+		t.Errorf("expected [4,5,6], got %v", result)
+	}
+	if meta.Total != 10 {
+		t.Errorf("expected total 10, got %d", meta.Total)
+	}
+}
+
+func TestPaginateSlice_LastPage(t *testing.T) {
+	items := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	result, meta := PaginateSlice(items, 4, 3)
+
+	if len(result) != 1 {
+		t.Errorf("expected 1 item on last page, got %d", len(result))
+	}
+	if result[0] != 10 {
+		t.Errorf("expected [10], got %v", result)
+	}
+	if meta.TotalPages != 4 {
+		t.Errorf("expected 4 pages, got %d", meta.TotalPages)
+	}
+}
+
+func TestPaginateSlice_BeyondTotal(t *testing.T) {
+	items := []int{1, 2, 3}
+	result, meta := PaginateSlice(items, 5, 3)
+
+	if len(result) != 0 {
+		t.Errorf("expected empty slice for page beyond total, got %d items", len(result))
+	}
+	if meta.Total != 3 {
+		t.Errorf("expected total 3, got %d", meta.Total)
+	}
+}
+
+func TestPaginateSlice_Empty(t *testing.T) {
+	items := []int{}
+	result, meta := PaginateSlice(items, 1, 10)
+
+	if len(result) != 0 {
+		t.Errorf("expected empty result, got %d items", len(result))
+	}
+	if meta.Total != 0 {
+		t.Errorf("expected total 0, got %d", meta.Total)
+	}
+	if meta.TotalPages != 0 {
+		t.Errorf("expected 0 pages, got %d", meta.TotalPages)
+	}
+}
+
+func TestPaginateSlice_ZeroLimit(t *testing.T) {
+	items := []int{1, 2, 3}
+	result, _ := PaginateSlice(items, 1, 0)
+
+	if len(result) != 3 {
+		t.Errorf("expected all items with zero limit, got %d", len(result))
+	}
+}
+
+func TestPaginateSlice_ExactFit(t *testing.T) {
+	items := []int{1, 2, 3, 4, 5, 6}
+	result, meta := PaginateSlice(items, 2, 3)
+
+	if len(result) != 3 {
+		t.Errorf("expected 3 items, got %d", len(result))
+	}
+	if meta.TotalPages != 2 {
+		t.Errorf("expected 2 pages for exact fit, got %d", meta.TotalPages)
+	}
+}
+
+func TestParsePaginationParams_NoPagination(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/v2/jobs", nil)
+	page, limit := ParsePaginationParams(req, 20)
+
+	if page != 0 || limit != 0 {
+		t.Errorf("expected (0,0) when no params, got (%d,%d)", page, limit)
+	}
+}
+
+func TestParsePaginationParams_WithPage(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/v2/jobs?page=3", nil)
+	page, limit := ParsePaginationParams(req, 20)
+
+	if page != 3 {
+		t.Errorf("expected page 3, got %d", page)
+	}
+	if limit != 20 {
+		t.Errorf("expected default limit 20, got %d", limit)
+	}
+}
+
+func TestParsePaginationParams_WithBoth(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/v2/jobs?page=2&limit=50", nil)
+	page, limit := ParsePaginationParams(req, 20)
+
+	if page != 2 {
+		t.Errorf("expected page 2, got %d", page)
+	}
+	if limit != 50 {
+		t.Errorf("expected limit 50, got %d", limit)
+	}
+}
+
+func TestParsePaginationParams_InvalidPage(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/v2/jobs?page=abc", nil)
+	page, limit := ParsePaginationParams(req, 20)
+
+	if page != 1 {
+		t.Errorf("expected default page 1 for invalid input, got %d", page)
+	}
+	if limit != 20 {
+		t.Errorf("expected default limit 20, got %d", limit)
+	}
+}
+
+func TestParsePaginationParams_NegativePage(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/v2/jobs?page=-1", nil)
+	page, _ := ParsePaginationParams(req, 20)
+
+	if page != 1 {
+		t.Errorf("expected default page 1 for negative input, got %d", page)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -235,6 +235,7 @@ func NewServer(port int, client client.Client, clientset kubernetes.Interface, n
 	mux.Handle(v2.GraphRunsPath+"/", authMw.RequireAuth(http.HandlerFunc(handler.GraphRunsRouter)))
 	mux.Handle(v2.DashboardActiveRunsPath, authMw.RequireAuth(http.HandlerFunc(handler.GetActiveRunsOverview)))
 	mux.Handle(v2.JobsPath, authMw.RequireAuth(http.HandlerFunc(handler.ListJobs)))
+	mux.Handle(v2.JobsPath+"/", authMw.RequireAuth(http.HandlerFunc(handler.ListJobs)))
 
 	// v2 WebSocket endpoints (NEW - real-time multiplexed updates)
 	// WebSocket authentication is handled internally via Sec-WebSocket-Protocol header

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -234,6 +234,7 @@ func NewServer(port int, client client.Client, clientset kubernetes.Interface, n
 	mux.Handle(v2.GraphRunsPath, authMw.RequireAuth(http.HandlerFunc(handler.GraphRunsRouter)))
 	mux.Handle(v2.GraphRunsPath+"/", authMw.RequireAuth(http.HandlerFunc(handler.GraphRunsRouter)))
 	mux.Handle(v2.DashboardActiveRunsPath, authMw.RequireAuth(http.HandlerFunc(handler.GetActiveRunsOverview)))
+	mux.Handle(v2.JobsPath, authMw.RequireAuth(http.HandlerFunc(handler.ListJobs)))
 
 	// v2 WebSocket endpoints (NEW - real-time multiplexed updates)
 	// WebSocket authentication is handled internally via Sec-WebSocket-Protocol header

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -406,6 +406,41 @@ type ScenarioRunListResponse struct {
 	ScenarioRuns []ScenarioRunListItem `json:"scenarioRuns"`
 }
 
+// PaginationMeta contains pagination metadata for paginated responses.
+type PaginationMeta struct {
+	// Page is the current page number (1-based), 0 if unpaginated
+	Page int `json:"page"`
+	// Limit is the number of items per page, 0 if unpaginated
+	Limit int `json:"limit"`
+	// Total is the total number of items matching the query
+	Total int `json:"total"`
+	// TotalPages is the total number of pages
+	TotalPages int `json:"totalPages"`
+}
+
+// UnifiedJobItem represents a single item in the unified jobs list.
+// It wraps either a ScenarioRun or a GraphRun with a type discriminator.
+type UnifiedJobItem struct {
+	// Type is the resource type: "scenarioRun" or "graphRun"
+	Type string `json:"type"`
+	// Name is the resource name
+	Name string `json:"name"`
+	// CreatedAt is the creation timestamp (used for sorting)
+	CreatedAt time.Time `json:"createdAt"`
+	// ScenarioRun contains the scenario run data (when Type == "scenarioRun")
+	ScenarioRun *ScenarioRunListItem `json:"scenarioRun,omitempty"`
+	// GraphRun contains the graph run data (when Type == "graphRun")
+	GraphRun *GraphRunListItem `json:"graphRun,omitempty"`
+}
+
+// UnifiedJobsResponse represents the response for GET /api/v2/jobs
+type UnifiedJobsResponse struct {
+	// Jobs is the list of unified job items
+	Jobs []UnifiedJobItem `json:"jobs"`
+	// Pagination contains pagination metadata
+	Pagination PaginationMeta `json:"pagination"`
+}
+
 // ActiveRunsOverviewResponse represents the response for GET /api/v1/dashboard/active-runs
 // It provides an overview of currently running scenario runs
 type ActiveRunsOverviewResponse struct {

--- a/internal/api/user_handlers.go
+++ b/internal/api/user_handlers.go
@@ -113,44 +113,6 @@ func filterUsers(users []krknv1alpha1.KrknUser, role, activeParam, search string
 	return filtered
 }
 
-// paginateUsers paginates a list of users
-func paginateUsers(users []krknv1alpha1.KrknUser, page, limit int) ([]krknv1alpha1.KrknUser, int) {
-	total := len(users)
-
-	// Calculate offset
-	offset := (page - 1) * limit
-	if offset >= total {
-		return []krknv1alpha1.KrknUser{}, total
-	}
-
-	// Calculate end index
-	end := offset + limit
-	if end > total {
-		end = total
-	}
-
-	return users[offset:end], total
-}
-
-// parsePaginationParams parses page and limit query parameters
-func parsePaginationParams(r *http.Request) (int, int) {
-	page := 1
-	limit := 50
-
-	if pageStr := r.URL.Query().Get("page"); pageStr != "" {
-		if p, err := strconv.Atoi(pageStr); err == nil && p > 0 {
-			page = p
-		}
-	}
-
-	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
-		if l, err := strconv.Atoi(limitStr); err == nil && l > 0 && l <= 100 {
-			limit = l
-		}
-	}
-
-	return page, limit
-}
 
 // sanitizeUsername converts an email to a valid Kubernetes resource name of the
 // form "krknuser-<sanitized>".
@@ -205,9 +167,15 @@ func (h *Handler) ListUsers(w http.ResponseWriter, r *http.Request) {
 	// Filter users
 	filtered := filterUsers(users.Items, role, activeParam, search)
 
-	// Paginate
-	page, limit := parsePaginationParams(r)
-	paginated, total := paginateUsers(filtered, page, limit)
+	// Paginate (users always paginate with default limit=50)
+	page, limit := ParsePaginationParams(r, 50)
+	if page == 0 {
+		page = 1
+	}
+	if limit == 0 {
+		limit = 50
+	}
+	paginated, meta := PaginateSlice(filtered, page, limit)
 
 	// Convert to response format
 	userResponses := make([]UserResponse, len(paginated))
@@ -215,13 +183,13 @@ func (h *Handler) ListUsers(w http.ResponseWriter, r *http.Request) {
 		userResponses[i] = buildUserResponse(&user)
 	}
 
-	logger.Info("Listed users", "total", total, "page", page, "limit", limit)
+	logger.Info("Listed users", "total", meta.Total, "page", meta.Page, "limit", meta.Limit)
 
 	writeJSON(w, http.StatusOK, ListUsersResponse{
 		Users: userResponses,
-		Total: total,
-		Page:  page,
-		Limit: limit,
+		Total: meta.Total,
+		Page:  meta.Page,
+		Limit: meta.Limit,
 	})
 }
 

--- a/internal/api/v2/routes.go
+++ b/internal/api/v2/routes.go
@@ -37,6 +37,9 @@ const (
 	// Graph Run endpoints (same as v1)
 	GraphRunsPath = APIBasePath + "/graphruns"
 
+	// Jobs endpoint (unified paginated view of ScenarioRuns + GraphRuns)
+	JobsPath = APIBasePath + "/jobs"
+
 	// Dashboard endpoints (same as v1)
 	DashboardPath           = APIBasePath + "/dashboard"
 	DashboardActiveRunsPath = DashboardPath + "/active-runs"

--- a/internal/api/v2/websocket/broadcaster.go
+++ b/internal/api/v2/websocket/broadcaster.go
@@ -321,6 +321,88 @@ func (b *Broadcaster) BroadcastGraphRunDeleted(graphRun *krknv1alpha1.KrknGraphR
 	b.cacheMu.Unlock()
 }
 
+// BroadcastJobsPageUpdate recomputes the paginated jobs page for each "jobs" subscriber
+// and sends an updated snapshot if the page content has changed.
+func (b *Broadcaster) BroadcastJobsPageUpdate() {
+	logger := log.Log.WithName("websocket-broadcast-jobs")
+
+	// List all ScenarioRuns
+	var scenarioRuns krknv1alpha1.KrknScenarioRunList
+	if err := b.k8sClient.List(context.Background(), &scenarioRuns, k8sclient.InNamespace(b.namespace)); err != nil {
+		logger.Error(err, "Failed to list scenario runs for jobs page update")
+		return
+	}
+
+	// List all GraphRuns
+	var graphRuns krknv1alpha1.KrknGraphRunList
+	if err := b.k8sClient.List(context.Background(), &graphRuns, k8sclient.InNamespace(b.namespace)); err != nil {
+		logger.Error(err, "Failed to list graph runs for jobs page update")
+		return
+	}
+
+	b.hub.ForEachSubscriber("jobs", func(client *Client) {
+		// Create auth context for this client
+		claims := &auth.Claims{
+			UserID: client.userID,
+			Role:   roleFromAdmin(client.isAdmin),
+		}
+		ctx := context.WithValue(context.Background(), auth.UserClaimsKey, claims)
+
+		// Apply per-user authorization filters
+		filteredScenarioRuns := b.authz.FilterScenarioRunsByGroupPermission(scenarioRuns.Items, ctx)
+		filteredGraphRuns := b.authz.FilterGraphRunsByGroupPermission(graphRuns.Items, ctx)
+
+		// Build unified sorted list
+		allJobs := buildUnifiedJobList(filteredScenarioRuns, filteredGraphRuns)
+
+		// Get this client's pagination state
+		client.mu.RLock()
+		ps := client.paginationState["jobs"]
+		client.mu.RUnlock()
+
+		if ps == nil {
+			return
+		}
+
+		// Paginate
+		pageItems, meta := paginateJobItems(allJobs, ps.Page, ps.Limit)
+
+		snapshot := WSUnifiedJobsSnapshot{Jobs: pageItems}
+		msg := ServerMessage{
+			Resource:   "jobs",
+			Event:      "snapshot",
+			Data:       snapshot,
+			Pagination: &meta,
+		}
+
+		data, err := json.Marshal(msg)
+		if err != nil {
+			logger.Error(err, "Failed to marshal jobs page update", "userId", client.userID)
+			return
+		}
+
+		// Check fingerprint — skip if page content unchanged
+		fp := hashBytes(data)
+		client.mu.Lock()
+		if ps.LastHash == fp {
+			client.mu.Unlock()
+			return
+		}
+		ps.LastHash = fp
+		client.mu.Unlock()
+
+		select {
+		case client.send <- data:
+			logger.V(1).Info("Sent jobs page update",
+				"userId", client.userID,
+				"page", meta.Page,
+				"total", meta.Total)
+		default:
+			logger.Error(nil, "Client buffer full, dropping jobs page update", "userId", client.userID)
+		}
+	})
+}
+
 // hashBytes computes a fast hash of a byte slice for deduplication
 func hashBytes(data []byte) uint64 {
 	h := fnv.New64a()

--- a/internal/api/v2/websocket/broadcaster.go
+++ b/internal/api/v2/websocket/broadcaster.go
@@ -323,19 +323,19 @@ func (b *Broadcaster) BroadcastGraphRunDeleted(graphRun *krknv1alpha1.KrknGraphR
 
 // BroadcastJobsPageUpdate recomputes the paginated jobs page for each "jobs" subscriber
 // and sends an updated snapshot if the page content has changed.
-func (b *Broadcaster) BroadcastJobsPageUpdate() {
+func (b *Broadcaster) BroadcastJobsPageUpdate(ctx context.Context) {
 	logger := log.Log.WithName("websocket-broadcast-jobs")
 
 	// List all ScenarioRuns
 	var scenarioRuns krknv1alpha1.KrknScenarioRunList
-	if err := b.k8sClient.List(context.Background(), &scenarioRuns, k8sclient.InNamespace(b.namespace)); err != nil {
+	if err := b.k8sClient.List(ctx, &scenarioRuns, k8sclient.InNamespace(b.namespace)); err != nil {
 		logger.Error(err, "Failed to list scenario runs for jobs page update")
 		return
 	}
 
 	// List all GraphRuns
 	var graphRuns krknv1alpha1.KrknGraphRunList
-	if err := b.k8sClient.List(context.Background(), &graphRuns, k8sclient.InNamespace(b.namespace)); err != nil {
+	if err := b.k8sClient.List(ctx, &graphRuns, k8sclient.InNamespace(b.namespace)); err != nil {
 		logger.Error(err, "Failed to list graph runs for jobs page update")
 		return
 	}

--- a/internal/api/v2/websocket/handler.go
+++ b/internal/api/v2/websocket/handler.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -29,6 +30,7 @@ import (
 	"github.com/gorilla/websocket"
 	krknv1alpha1 "github.com/krkn-chaos/krkn-operator/api/v1alpha1"
 	"github.com/krkn-chaos/krkn-operator/pkg/auth"
+	kvstore "github.com/krkn-chaos/krkn-operator/pkg/configstore"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -193,11 +195,12 @@ func (h *Handler) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 	// Create client and register with hub
 	client := &Client{
-		conn:          conn,
-		userID:        claims.UserID,
-		isAdmin:       claims.Role == "admin",
-		send:          make(chan []byte, 256),
-		subscriptions: make(map[string]map[string]bool),
+		conn:            conn,
+		userID:          claims.UserID,
+		isAdmin:         claims.Role == "admin",
+		send:            make(chan []byte, 256),
+		subscriptions:   make(map[string]map[string]bool),
+		paginationState: make(map[string]*PaginationClientState),
 	}
 
 	h.hub.register <- client
@@ -300,14 +303,33 @@ func (h *Handler) handleClientMessage(client *Client, msg *ClientMessage) {
 			"run-detail": true, // Full ScenarioRun with clusterJobs
 			"graphrun":   true,
 			"dashboard":  true,
+			"jobs":       true, // Unified paginated view
 		}
 		if !validResources[msg.Resource] {
-			h.sendError(client, "invalid_resource", "Invalid resource type. Valid: run, run-detail, graphrun, dashboard")
+			h.sendError(client, "invalid_resource", "Invalid resource type. Valid: run, run-detail, graphrun, dashboard, jobs")
 			return
 		}
 
 		// Subscribe client
 		client.Subscribe(msg.Resource, msg.IDs)
+
+		// Store pagination state for "jobs" subscriptions
+		if msg.Resource == "jobs" {
+			page := 1
+			limit := h.getDefaultPageSize()
+			if msg.Page != nil && *msg.Page > 0 {
+				page = *msg.Page
+			}
+			if msg.Limit != nil && *msg.Limit > 0 {
+				limit = *msg.Limit
+			}
+			client.mu.Lock()
+			client.paginationState["jobs"] = &PaginationClientState{
+				Page:  page,
+				Limit: limit,
+			}
+			client.mu.Unlock()
+		}
 
 		logger.Info("Client subscribed",
 			"userId", client.userID,
@@ -362,6 +384,16 @@ func roleFromAdmin(isAdmin bool) string {
 	return string(auth.RoleUser)
 }
 
+// getDefaultPageSize reads the default page size from configstore.
+func (h *Handler) getDefaultPageSize() int {
+	if val, ok := kvstore.Get().GetValue("jobs.defaultPageSize"); ok {
+		if n, err := strconv.Atoi(val); err == nil && n > 0 {
+			return n
+		}
+	}
+	return 20
+}
+
 // sendInitialSnapshot sends the current state of resources to a newly subscribed client
 func (h *Handler) sendInitialSnapshot(client *Client, resourceType string, resourceIDs []string) {
 	// Skip snapshot if k8sClient is not available (e.g., in tests)
@@ -386,6 +418,8 @@ func (h *Handler) sendInitialSnapshot(client *Client, resourceType string, resou
 		h.sendScenarioRunDetailSnapshot(ctx, client, resourceIDs, logger)
 	case "graphrun":
 		h.sendGraphRunsSnapshot(ctx, client, resourceIDs, logger)
+	case "jobs":
+		h.sendJobsSnapshot(ctx, client, logger)
 	case "dashboard":
 		// Dashboard is a global subscription - no snapshot needed as it will be broadcasted
 		logger.V(1).Info("Dashboard subscription - no initial snapshot needed")
@@ -570,5 +604,73 @@ func (h *Handler) sendGraphRunsSnapshot(ctx context.Context, client *Client, res
 		default:
 			logger.Error(nil, "Client buffer full, dropping snapshot", "runName", run.Name)
 		}
+	}
+}
+
+// sendJobsSnapshot sends a paginated unified jobs snapshot to the client.
+func (h *Handler) sendJobsSnapshot(ctx context.Context, client *Client, logger logr.Logger) {
+	// List ScenarioRuns
+	var scenarioRuns krknv1alpha1.KrknScenarioRunList
+	if err := h.k8sClient.List(ctx, &scenarioRuns, k8sclient.InNamespace(h.namespace)); err != nil {
+		logger.Error(err, "Failed to list scenario runs for jobs snapshot")
+		return
+	}
+
+	// List GraphRuns
+	var graphRuns krknv1alpha1.KrknGraphRunList
+	if err := h.k8sClient.List(ctx, &graphRuns, k8sclient.InNamespace(h.namespace)); err != nil {
+		logger.Error(err, "Failed to list graph runs for jobs snapshot")
+		return
+	}
+
+	// Apply authorization filters
+	filteredScenarioRuns := h.authz.FilterScenarioRunsByGroupPermission(scenarioRuns.Items, ctx)
+	filteredGraphRuns := h.authz.FilterGraphRunsByGroupPermission(graphRuns.Items, ctx)
+
+	// Build unified sorted list
+	allJobs := buildUnifiedJobList(filteredScenarioRuns, filteredGraphRuns)
+
+	// Get pagination state
+	client.mu.RLock()
+	ps := client.paginationState["jobs"]
+	client.mu.RUnlock()
+
+	page := 1
+	limit := h.getDefaultPageSize()
+	if ps != nil {
+		page = ps.Page
+		limit = ps.Limit
+	}
+
+	// Paginate
+	pageItems, meta := paginateJobItems(allJobs, page, limit)
+
+	snapshot := WSUnifiedJobsSnapshot{Jobs: pageItems}
+	msg := ServerMessage{
+		Resource:   "jobs",
+		Event:      "snapshot",
+		Data:       snapshot,
+		Pagination: &meta,
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		logger.Error(err, "Failed to marshal jobs snapshot")
+		return
+	}
+
+	// Update fingerprint
+	fp := hashBytes(data)
+	client.mu.Lock()
+	if client.paginationState["jobs"] != nil {
+		client.paginationState["jobs"].LastHash = fp
+	}
+	client.mu.Unlock()
+
+	select {
+	case client.send <- data:
+		logger.Info("Sent jobs snapshot", "page", meta.Page, "limit", meta.Limit, "total", meta.Total, "items", len(pageItems))
+	default:
+		logger.Error(nil, "Client buffer full, dropping jobs snapshot")
 	}
 }

--- a/internal/api/v2/websocket/hub.go
+++ b/internal/api/v2/websocket/hub.go
@@ -25,6 +25,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+// PaginationClientState tracks per-client pagination state for a resource type.
+type PaginationClientState struct {
+	Page     int
+	Limit    int
+	LastHash uint64 // fingerprint of last sent page content
+}
+
 // Client represents a connected WebSocket client
 type Client struct {
 	// WebSocket connection
@@ -42,6 +49,9 @@ type Client struct {
 	// Subscriptions: map[resourceType]map[resourceID]bool
 	// Example: subscriptions["run"]["run-abc123"] = true
 	subscriptions map[string]map[string]bool
+
+	// Pagination state per resource type (e.g., "jobs" → page/limit)
+	paginationState map[string]*PaginationClientState
 
 	// Mutex for subscription updates
 	mu sync.RWMutex
@@ -196,6 +206,21 @@ func (c *Client) Unsubscribe(resourceType string, resourceIDs []string) {
 
 	for _, id := range resourceIDs {
 		delete(c.subscriptions[resourceType], id)
+	}
+}
+
+// ForEachSubscriber calls fn for each client subscribed to the given resource type.
+// The caller must not call Hub methods inside fn to avoid deadlock.
+func (h *Hub) ForEachSubscriber(resourceType string, fn func(*Client)) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	for client := range h.clients {
+		client.mu.RLock()
+		_, subscribed := client.subscriptions[resourceType]
+		client.mu.RUnlock()
+		if subscribed {
+			fn(client)
+		}
 	}
 }
 

--- a/internal/api/v2/websocket/hub.go
+++ b/internal/api/v2/websocket/hub.go
@@ -195,7 +195,8 @@ func (c *Client) Subscribe(resourceType string, resourceIDs []string) {
 	}
 }
 
-// Unsubscribe removes resource subscriptions for a client
+// Unsubscribe removes resource subscriptions for a client.
+// Cleans up the resource key and pagination state when no subscriptions remain.
 func (c *Client) Unsubscribe(resourceType string, resourceIDs []string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -207,20 +208,32 @@ func (c *Client) Unsubscribe(resourceType string, resourceIDs []string) {
 	for _, id := range resourceIDs {
 		delete(c.subscriptions[resourceType], id)
 	}
+
+	if len(c.subscriptions[resourceType]) == 0 {
+		delete(c.subscriptions, resourceType)
+		delete(c.paginationState, resourceType)
+	}
 }
 
 // ForEachSubscriber calls fn for each client subscribed to the given resource type.
-// The caller must not call Hub methods inside fn to avoid deadlock.
+// Snapshots the matching client set under a short lock so fn can do expensive work
+// without blocking hub register/unregister.
 func (h *Hub) ForEachSubscriber(resourceType string, fn func(*Client)) {
 	h.mu.RLock()
-	defer h.mu.RUnlock()
+	subscribers := make([]*Client, 0, len(h.clients))
 	for client := range h.clients {
 		client.mu.RLock()
-		_, subscribed := client.subscriptions[resourceType]
+		subs, ok := client.subscriptions[resourceType]
+		hasActive := ok && len(subs) > 0
 		client.mu.RUnlock()
-		if subscribed {
-			fn(client)
+		if hasActive {
+			subscribers = append(subscribers, client)
 		}
+	}
+	h.mu.RUnlock()
+
+	for _, client := range subscribers {
+		fn(client)
 	}
 }
 

--- a/internal/api/v2/websocket/jobs_test.go
+++ b/internal/api/v2/websocket/jobs_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package websocket
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -256,7 +257,7 @@ func TestBroadcastJobsPageUpdate(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// Trigger page update
-	broadcaster.BroadcastJobsPageUpdate()
+	broadcaster.BroadcastJobsPageUpdate(context.Background())
 
 	select {
 	case data := <-client.send:
@@ -332,7 +333,7 @@ func TestBroadcastJobsPageUpdate_Dedup(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// First broadcast should send
-	broadcaster.BroadcastJobsPageUpdate()
+	broadcaster.BroadcastJobsPageUpdate(context.Background())
 
 	select {
 	case <-client.send:
@@ -342,13 +343,79 @@ func TestBroadcastJobsPageUpdate_Dedup(t *testing.T) {
 	}
 
 	// Second broadcast with same data should be deduplicated
-	broadcaster.BroadcastJobsPageUpdate()
+	broadcaster.BroadcastJobsPageUpdate(context.Background())
 
 	select {
 	case <-client.send:
 		t.Error("expected second broadcast to be deduplicated (no message)")
 	case <-time.After(100 * time.Millisecond):
 		// expected: no message due to dedup
+	}
+}
+
+func TestUnsubscribe_CleansUpJobsState(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = krknv1alpha1.AddToScheme(scheme)
+
+	sr := &krknv1alpha1.KrknScenarioRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "sr-1",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(time.Now()),
+			Labels:            map[string]string{},
+		},
+		Status: krknv1alpha1.KrknScenarioRunStatus{Phase: "Running"},
+	}
+
+	fakeClient := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(sr).
+		Build()
+
+	hub := NewHub()
+	go hub.Run()
+
+	broadcaster := NewBroadcaster(hub, &mockAuthzChecker{}, fakeClient, "default")
+
+	client := &Client{
+		userID:  "test-user",
+		isAdmin: true,
+		send:    make(chan []byte, 256),
+		subscriptions: map[string]map[string]bool{
+			"jobs": {"*": true},
+		},
+		paginationState: map[string]*PaginationClientState{
+			"jobs": {Page: 1, Limit: 10},
+		},
+	}
+
+	hub.register <- client
+	time.Sleep(10 * time.Millisecond)
+
+	// Unsubscribe from jobs
+	client.Unsubscribe("jobs", []string{"*"})
+
+	// Verify subscription and pagination state cleaned up
+	client.mu.RLock()
+	_, hasSub := client.subscriptions["jobs"]
+	_, hasPS := client.paginationState["jobs"]
+	client.mu.RUnlock()
+
+	if hasSub {
+		t.Error("expected jobs subscription to be removed after unsubscribe")
+	}
+	if hasPS {
+		t.Error("expected jobs pagination state to be removed after unsubscribe")
+	}
+
+	// Broadcast should NOT send to unsubscribed client
+	broadcaster.BroadcastJobsPageUpdate(context.Background())
+
+	select {
+	case <-client.send:
+		t.Error("expected no message after unsubscribe")
+	case <-time.After(100 * time.Millisecond):
+		// expected: no message
 	}
 }
 

--- a/internal/api/v2/websocket/jobs_test.go
+++ b/internal/api/v2/websocket/jobs_test.go
@@ -1,0 +1,423 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package websocket
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	krknv1alpha1 "github.com/krkn-chaos/krkn-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestHandleClientMessage_JobsSubscribe(t *testing.T) {
+	hub := NewHub()
+	handler := NewHandler(hub, nil, "test-namespace", &mockAuthzChecker{}, nil)
+
+	client := &Client{
+		userID:          "test-user",
+		isAdmin:         false,
+		send:            make(chan []byte, 256),
+		subscriptions:   make(map[string]map[string]bool),
+		paginationState: make(map[string]*PaginationClientState),
+	}
+
+	page := 2
+	limit := 5
+	msg := &ClientMessage{
+		Action:   "subscribe",
+		Resource: "jobs",
+		Page:     &page,
+		Limit:    &limit,
+	}
+
+	handler.handleClientMessage(client, msg)
+
+	// Verify subscription was created
+	client.mu.RLock()
+	_, subscribed := client.subscriptions["jobs"]
+	ps := client.paginationState["jobs"]
+	client.mu.RUnlock()
+
+	if !subscribed {
+		t.Error("expected client to be subscribed to 'jobs'")
+	}
+	if ps == nil {
+		t.Fatal("expected pagination state to be set")
+	}
+	if ps.Page != 2 {
+		t.Errorf("expected page 2, got %d", ps.Page)
+	}
+	if ps.Limit != 5 {
+		t.Errorf("expected limit 5, got %d", ps.Limit)
+	}
+}
+
+func TestHandleClientMessage_JobsSubscribeDefaults(t *testing.T) {
+	hub := NewHub()
+	handler := NewHandler(hub, nil, "test-namespace", &mockAuthzChecker{}, nil)
+
+	client := &Client{
+		userID:          "test-user",
+		isAdmin:         false,
+		send:            make(chan []byte, 256),
+		subscriptions:   make(map[string]map[string]bool),
+		paginationState: make(map[string]*PaginationClientState),
+	}
+
+	msg := &ClientMessage{
+		Action:   "subscribe",
+		Resource: "jobs",
+	}
+
+	handler.handleClientMessage(client, msg)
+
+	client.mu.RLock()
+	ps := client.paginationState["jobs"]
+	client.mu.RUnlock()
+
+	if ps == nil {
+		t.Fatal("expected pagination state to be set")
+	}
+	if ps.Page != 1 {
+		t.Errorf("expected default page 1, got %d", ps.Page)
+	}
+	if ps.Limit <= 0 {
+		t.Errorf("expected positive default limit, got %d", ps.Limit)
+	}
+}
+
+func TestSendJobsSnapshot(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = krknv1alpha1.AddToScheme(scheme)
+
+	now := time.Now()
+	sr1 := &krknv1alpha1.KrknScenarioRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "sr-1",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(now.Add(-2 * time.Hour)),
+			Labels:            map[string]string{},
+		},
+		Status: krknv1alpha1.KrknScenarioRunStatus{Phase: "Succeeded"},
+	}
+	sr2 := &krknv1alpha1.KrknScenarioRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "sr-2",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(now.Add(-1 * time.Hour)),
+			Labels:            map[string]string{},
+		},
+		Status: krknv1alpha1.KrknScenarioRunStatus{Phase: "Running"},
+	}
+	gr1 := &krknv1alpha1.KrknGraphRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "gr-1",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(now),
+		},
+		Status: krknv1alpha1.KrknGraphRunStatus{Phase: "Running"},
+	}
+
+	fakeClient := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(sr1, sr2, gr1).
+		Build()
+
+	hub := NewHub()
+	handler := NewHandler(hub, fakeClient, "default", &mockAuthzChecker{}, nil)
+
+	client := &Client{
+		userID:          "test-user",
+		isAdmin:         true,
+		send:            make(chan []byte, 256),
+		subscriptions:   make(map[string]map[string]bool),
+		paginationState: make(map[string]*PaginationClientState),
+	}
+
+	// Subscribe with page 1, limit 2
+	page := 1
+	limit := 2
+	msg := &ClientMessage{
+		Action:   "subscribe",
+		Resource: "jobs",
+		Page:     &page,
+		Limit:    &limit,
+	}
+	handler.handleClientMessage(client, msg)
+
+	// Read the snapshot message
+	select {
+	case data := <-client.send:
+		var serverMsg ServerMessage
+		if err := json.Unmarshal(data, &serverMsg); err != nil {
+			t.Fatalf("failed to unmarshal: %v", err)
+		}
+
+		if serverMsg.Resource != "jobs" {
+			t.Errorf("expected resource 'jobs', got '%s'", serverMsg.Resource)
+		}
+		if serverMsg.Event != "snapshot" {
+			t.Errorf("expected event 'snapshot', got '%s'", serverMsg.Event)
+		}
+		if serverMsg.Pagination == nil {
+			t.Fatal("expected pagination metadata")
+		}
+		if serverMsg.Pagination.Total != 3 {
+			t.Errorf("expected total 3, got %d", serverMsg.Pagination.Total)
+		}
+		if serverMsg.Pagination.TotalPages != 2 {
+			t.Errorf("expected 2 pages, got %d", serverMsg.Pagination.TotalPages)
+		}
+		if serverMsg.Pagination.Page != 1 {
+			t.Errorf("expected page 1, got %d", serverMsg.Pagination.Page)
+		}
+
+		// Parse the data to verify items
+		dataBytes, _ := json.Marshal(serverMsg.Data)
+		var snapshot WSUnifiedJobsSnapshot
+		if err := json.Unmarshal(dataBytes, &snapshot); err != nil {
+			t.Fatalf("failed to unmarshal snapshot data: %v", err)
+		}
+		if len(snapshot.Jobs) != 2 {
+			t.Errorf("expected 2 items on page 1, got %d", len(snapshot.Jobs))
+		}
+
+	case <-time.After(time.Second):
+		t.Error("timeout waiting for snapshot message")
+	}
+}
+
+func TestBroadcastJobsPageUpdate(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = krknv1alpha1.AddToScheme(scheme)
+
+	now := time.Now()
+	sr1 := &krknv1alpha1.KrknScenarioRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "sr-1",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(now.Add(-2 * time.Hour)),
+			Labels:            map[string]string{},
+		},
+		Status: krknv1alpha1.KrknScenarioRunStatus{Phase: "Running"},
+	}
+	sr2 := &krknv1alpha1.KrknScenarioRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "sr-2",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(now.Add(-1 * time.Hour)),
+			Labels:            map[string]string{},
+		},
+		Status: krknv1alpha1.KrknScenarioRunStatus{Phase: "Running"},
+	}
+
+	fakeClient := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(sr1, sr2).
+		Build()
+
+	hub := NewHub()
+	go hub.Run()
+
+	broadcaster := NewBroadcaster(hub, &mockAuthzChecker{}, fakeClient, "default")
+
+	// Client on page 1 with limit 1
+	client := &Client{
+		userID:  "test-user",
+		isAdmin: true,
+		send:    make(chan []byte, 256),
+		subscriptions: map[string]map[string]bool{
+			"jobs": {"*": true},
+		},
+		paginationState: map[string]*PaginationClientState{
+			"jobs": {Page: 1, Limit: 1},
+		},
+	}
+
+	hub.register <- client
+	time.Sleep(10 * time.Millisecond)
+
+	// Trigger page update
+	broadcaster.BroadcastJobsPageUpdate()
+
+	select {
+	case data := <-client.send:
+		var serverMsg ServerMessage
+		if err := json.Unmarshal(data, &serverMsg); err != nil {
+			t.Fatalf("failed to unmarshal: %v", err)
+		}
+
+		if serverMsg.Resource != "jobs" {
+			t.Errorf("expected resource 'jobs', got '%s'", serverMsg.Resource)
+		}
+		if serverMsg.Pagination == nil {
+			t.Fatal("expected pagination metadata")
+		}
+		if serverMsg.Pagination.Total != 2 {
+			t.Errorf("expected total 2, got %d", serverMsg.Pagination.Total)
+		}
+		if serverMsg.Pagination.Page != 1 {
+			t.Errorf("expected page 1, got %d", serverMsg.Pagination.Page)
+		}
+
+		dataBytes, _ := json.Marshal(serverMsg.Data)
+		var snapshot WSUnifiedJobsSnapshot
+		if err := json.Unmarshal(dataBytes, &snapshot); err != nil {
+			t.Fatalf("failed to unmarshal snapshot: %v", err)
+		}
+		if len(snapshot.Jobs) != 1 {
+			t.Errorf("expected 1 item on page 1 (limit 1), got %d", len(snapshot.Jobs))
+		}
+
+	case <-time.After(time.Second):
+		t.Error("timeout waiting for broadcast")
+	}
+}
+
+func TestBroadcastJobsPageUpdate_Dedup(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = krknv1alpha1.AddToScheme(scheme)
+
+	sr := &krknv1alpha1.KrknScenarioRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "sr-1",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(time.Now()),
+			Labels:            map[string]string{},
+		},
+		Status: krknv1alpha1.KrknScenarioRunStatus{Phase: "Running"},
+	}
+
+	fakeClient := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(sr).
+		Build()
+
+	hub := NewHub()
+	go hub.Run()
+
+	broadcaster := NewBroadcaster(hub, &mockAuthzChecker{}, fakeClient, "default")
+
+	client := &Client{
+		userID:  "test-user",
+		isAdmin: true,
+		send:    make(chan []byte, 256),
+		subscriptions: map[string]map[string]bool{
+			"jobs": {"*": true},
+		},
+		paginationState: map[string]*PaginationClientState{
+			"jobs": {Page: 1, Limit: 10},
+		},
+	}
+
+	hub.register <- client
+	time.Sleep(10 * time.Millisecond)
+
+	// First broadcast should send
+	broadcaster.BroadcastJobsPageUpdate()
+
+	select {
+	case <-client.send:
+		// expected
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for first broadcast")
+	}
+
+	// Second broadcast with same data should be deduplicated
+	broadcaster.BroadcastJobsPageUpdate()
+
+	select {
+	case <-client.send:
+		t.Error("expected second broadcast to be deduplicated (no message)")
+	case <-time.After(100 * time.Millisecond):
+		// expected: no message due to dedup
+	}
+}
+
+func TestBuildUnifiedJobList_SkipsGraphRunChildren(t *testing.T) {
+	now := time.Now()
+
+	scenarioRuns := []krknv1alpha1.KrknScenarioRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "standalone",
+				CreationTimestamp: metav1.NewTime(now),
+				Labels:            map[string]string{},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "graph-child",
+				CreationTimestamp: metav1.NewTime(now.Add(-time.Hour)),
+				Labels:            map[string]string{"krkn.dev/graph-run": "parent"},
+			},
+		},
+	}
+
+	graphRuns := []krknv1alpha1.KrknGraphRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "parent",
+				CreationTimestamp: metav1.NewTime(now.Add(-30 * time.Minute)),
+			},
+		},
+	}
+
+	jobs := buildUnifiedJobList(scenarioRuns, graphRuns)
+
+	if len(jobs) != 2 {
+		t.Errorf("expected 2 items (standalone + parent graph), got %d", len(jobs))
+	}
+
+	for _, job := range jobs {
+		if job.Name == "graph-child" {
+			t.Error("graph-run child should not appear in unified list")
+		}
+	}
+}
+
+func TestPaginateJobItems(t *testing.T) {
+	items := make([]WSUnifiedJobItem, 10)
+	for i := range items {
+		items[i] = WSUnifiedJobItem{Name: "item"}
+	}
+
+	// Page 1 of 10 items with limit 3
+	page, meta := paginateJobItems(items, 1, 3)
+	if len(page) != 3 {
+		t.Errorf("expected 3 items, got %d", len(page))
+	}
+	if meta.Total != 10 {
+		t.Errorf("expected total 10, got %d", meta.Total)
+	}
+	if meta.TotalPages != 4 {
+		t.Errorf("expected 4 pages, got %d", meta.TotalPages)
+	}
+
+	// Beyond total
+	page, meta = paginateJobItems(items, 100, 3)
+	if len(page) != 0 {
+		t.Errorf("expected 0 items beyond total, got %d", len(page))
+	}
+	if meta.Total != 10 {
+		t.Errorf("expected total 10 even beyond range, got %d", meta.Total)
+	}
+}

--- a/internal/api/v2/websocket/response_helpers.go
+++ b/internal/api/v2/websocket/response_helpers.go
@@ -1,11 +1,92 @@
 package websocket
 
 import (
+	"math"
+	"sort"
 	"time"
 
 	krknv1alpha1 "github.com/krkn-chaos/krkn-operator/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// WSUnifiedJobItem represents a single item in the unified jobs list for WebSocket responses.
+type WSUnifiedJobItem struct {
+	Type      string      `json:"type"`      // "scenarioRun" or "graphRun"
+	Name      string      `json:"name"`
+	CreatedAt string      `json:"createdAt"` // RFC3339 timestamp
+	Data      interface{} `json:"data"`      // ScenarioRunStatusResponse or GraphRunResponse
+}
+
+// WSUnifiedJobsSnapshot represents the paginated jobs snapshot sent to WebSocket clients.
+type WSUnifiedJobsSnapshot struct {
+	Jobs []WSUnifiedJobItem `json:"jobs"`
+}
+
+// buildUnifiedJobList merges standalone ScenarioRuns and GraphRuns into a unified sorted list.
+func buildUnifiedJobList(scenarioRuns []krknv1alpha1.KrknScenarioRun, graphRuns []krknv1alpha1.KrknGraphRun) []WSUnifiedJobItem {
+	jobs := make([]WSUnifiedJobItem, 0, len(scenarioRuns)+len(graphRuns))
+
+	for i := range scenarioRuns {
+		sr := &scenarioRuns[i]
+		if sr.Labels["krkn.dev/graph-run"] != "" {
+			continue
+		}
+		jobs = append(jobs, WSUnifiedJobItem{
+			Type:      "scenarioRun",
+			Name:      sr.Name,
+			CreatedAt: sr.CreationTimestamp.Format(time.RFC3339),
+			Data:      buildScenarioRunResponse(sr),
+		})
+	}
+
+	for i := range graphRuns {
+		gr := &graphRuns[i]
+		jobs = append(jobs, WSUnifiedJobItem{
+			Type:      "graphRun",
+			Name:      gr.Name,
+			CreatedAt: gr.CreationTimestamp.Format(time.RFC3339),
+			Data:      buildGraphRunResponse(gr),
+		})
+	}
+
+	sort.Slice(jobs, func(i, j int) bool {
+		return jobs[i].CreatedAt > jobs[j].CreatedAt
+	})
+
+	return jobs
+}
+
+// paginateJobItems returns a page of items and pagination metadata.
+func paginateJobItems(items []WSUnifiedJobItem, page, limit int) ([]WSUnifiedJobItem, WSPaginationMeta) {
+	total := len(items)
+	totalPages := 0
+	if limit > 0 {
+		totalPages = int(math.Ceil(float64(total) / float64(limit)))
+	}
+
+	meta := WSPaginationMeta{
+		Page:       page,
+		Limit:      limit,
+		Total:      total,
+		TotalPages: totalPages,
+	}
+
+	if limit <= 0 || page <= 0 {
+		return items, meta
+	}
+
+	offset := (page - 1) * limit
+	if offset >= total {
+		return []WSUnifiedJobItem{}, meta
+	}
+
+	end := offset + limit
+	if end > total {
+		end = total
+	}
+
+	return items[offset:end], meta
+}
 
 // buildScenarioRunResponse builds the response with sanitized clusterJobs (no ClusterAPIURL).
 // Used for both lightweight "run" broadcasts and "run" snapshots.

--- a/internal/api/v2/websocket/types.go
+++ b/internal/api/v2/websocket/types.go
@@ -94,19 +94,31 @@ type ClusterJobResponse struct {
 	FailureReason   string     `json:"failureReason,omitempty"`
 }
 
+// WSPaginationMeta contains pagination metadata for paginated WebSocket responses.
+// Duplicated from internal/api to avoid import cycles.
+type WSPaginationMeta struct {
+	Page       int `json:"page"`
+	Limit      int `json:"limit"`
+	Total      int `json:"total"`
+	TotalPages int `json:"totalPages"`
+}
+
 // ServerMessage is sent from server to client
 type ServerMessage struct {
-	Resource string      `json:"resource"`     // "run", "graphrun", "dashboard"
-	ID       string      `json:"id,omitempty"` // resource ID (empty for dashboard)
-	Event    string      `json:"event"`        // "updated", "deleted", "snapshot"
-	Data     interface{} `json:"data"`
+	Resource   string            `json:"resource"`              // "run", "graphrun", "dashboard", "jobs"
+	ID         string            `json:"id,omitempty"`          // resource ID (empty for dashboard/jobs)
+	Event      string            `json:"event"`                 // "updated", "deleted", "snapshot"
+	Data       interface{}       `json:"data"`                  // payload
+	Pagination *WSPaginationMeta `json:"pagination,omitempty"`  // pagination metadata (for "jobs" resource)
 }
 
 // ClientMessage is sent from client to server
 type ClientMessage struct {
 	Action   string   `json:"action"`        // "subscribe", "unsubscribe"
-	Resource string   `json:"resource"`      // "run", "graphrun", "dashboard"
+	Resource string   `json:"resource"`      // "run", "graphrun", "dashboard", "jobs"
 	IDs      []string `json:"ids,omitempty"` // specific resource IDs (empty = wildcard)
+	Page     *int     `json:"page,omitempty"`  // page number for paginated subscriptions (1-based)
+	Limit    *int     `json:"limit,omitempty"` // items per page for paginated subscriptions
 }
 
 // ErrorMessage is sent when an error occurs

--- a/internal/api/v2/websocket/watcher.go
+++ b/internal/api/v2/websocket/watcher.go
@@ -93,7 +93,7 @@ func (h *scenarioRunEventHandler) OnAdd(obj interface{}, _ bool) {
 	// Broadcaster will deduplicate via cache, so always call it
 	h.broadcaster.BroadcastScenarioRunUpdate(run)       // Lightweight (no clusterJobs)
 	h.broadcaster.BroadcastScenarioRunDetailUpdate(run) // Full detail (with clusterJobs)
-	h.broadcaster.BroadcastJobsPageUpdate()             // Unified paginated view
+	h.broadcaster.BroadcastJobsPageUpdate(context.Background())             // Unified paginated view
 }
 
 func (h *scenarioRunEventHandler) OnUpdate(oldObj, newObj interface{}) {
@@ -124,7 +124,7 @@ func (h *scenarioRunEventHandler) OnUpdate(oldObj, newObj interface{}) {
 
 	h.broadcaster.BroadcastScenarioRunUpdate(newRun)       // Lightweight (no clusterJobs)
 	h.broadcaster.BroadcastScenarioRunDetailUpdate(newRun) // Full detail (with clusterJobs)
-	h.broadcaster.BroadcastJobsPageUpdate()                // Unified paginated view
+	h.broadcaster.BroadcastJobsPageUpdate(context.Background())                // Unified paginated view
 
 	// Update dashboard with current active runs count
 	h.broadcastDashboardUpdate(context.Background())
@@ -150,7 +150,7 @@ func (h *scenarioRunEventHandler) OnDelete(obj interface{}) {
 
 	h.logger.V(1).Info("ScenarioRun deleted", "name", run.Name)
 	h.broadcaster.BroadcastScenarioRunDeleted(run)
-	h.broadcaster.BroadcastJobsPageUpdate()
+	h.broadcaster.BroadcastJobsPageUpdate(context.Background())
 }
 
 // graphRunEventHandler handles GraphRun events and broadcasts to WebSocket clients
@@ -163,7 +163,7 @@ func (h *graphRunEventHandler) OnAdd(obj interface{}, _ bool) {
 	run := obj.(*krknv1alpha1.KrknGraphRun)
 	h.logger.V(1).Info("GraphRun added", "name", run.Name)
 	h.broadcaster.BroadcastGraphRunUpdate(run, "created")
-	h.broadcaster.BroadcastJobsPageUpdate()
+	h.broadcaster.BroadcastJobsPageUpdate(context.Background())
 }
 
 func (h *graphRunEventHandler) OnUpdate(oldObj, newObj interface{}) {
@@ -185,7 +185,7 @@ func (h *graphRunEventHandler) OnUpdate(oldObj, newObj interface{}) {
 		"completedNodes", newRun.Status.Summary.CompletedNodes)
 
 	h.broadcaster.BroadcastGraphRunUpdate(newRun, "updated")
-	h.broadcaster.BroadcastJobsPageUpdate()
+	h.broadcaster.BroadcastJobsPageUpdate(context.Background())
 }
 
 func (h *graphRunEventHandler) OnDelete(obj interface{}) {
@@ -208,7 +208,7 @@ func (h *graphRunEventHandler) OnDelete(obj interface{}) {
 
 	h.logger.V(1).Info("GraphRun deleted", "name", run.Name)
 	h.broadcaster.BroadcastGraphRunDeleted(run)
-	h.broadcaster.BroadcastJobsPageUpdate()
+	h.broadcaster.BroadcastJobsPageUpdate(context.Background())
 }
 
 // hasScenarioRunStatusChanged checks if ScenarioRun status has meaningful changes

--- a/internal/api/v2/websocket/watcher.go
+++ b/internal/api/v2/websocket/watcher.go
@@ -93,6 +93,7 @@ func (h *scenarioRunEventHandler) OnAdd(obj interface{}, _ bool) {
 	// Broadcaster will deduplicate via cache, so always call it
 	h.broadcaster.BroadcastScenarioRunUpdate(run)       // Lightweight (no clusterJobs)
 	h.broadcaster.BroadcastScenarioRunDetailUpdate(run) // Full detail (with clusterJobs)
+	h.broadcaster.BroadcastJobsPageUpdate()             // Unified paginated view
 }
 
 func (h *scenarioRunEventHandler) OnUpdate(oldObj, newObj interface{}) {
@@ -123,6 +124,7 @@ func (h *scenarioRunEventHandler) OnUpdate(oldObj, newObj interface{}) {
 
 	h.broadcaster.BroadcastScenarioRunUpdate(newRun)       // Lightweight (no clusterJobs)
 	h.broadcaster.BroadcastScenarioRunDetailUpdate(newRun) // Full detail (with clusterJobs)
+	h.broadcaster.BroadcastJobsPageUpdate()                // Unified paginated view
 
 	// Update dashboard with current active runs count
 	h.broadcastDashboardUpdate(context.Background())
@@ -148,6 +150,7 @@ func (h *scenarioRunEventHandler) OnDelete(obj interface{}) {
 
 	h.logger.V(1).Info("ScenarioRun deleted", "name", run.Name)
 	h.broadcaster.BroadcastScenarioRunDeleted(run)
+	h.broadcaster.BroadcastJobsPageUpdate()
 }
 
 // graphRunEventHandler handles GraphRun events and broadcasts to WebSocket clients
@@ -160,6 +163,7 @@ func (h *graphRunEventHandler) OnAdd(obj interface{}, _ bool) {
 	run := obj.(*krknv1alpha1.KrknGraphRun)
 	h.logger.V(1).Info("GraphRun added", "name", run.Name)
 	h.broadcaster.BroadcastGraphRunUpdate(run, "created")
+	h.broadcaster.BroadcastJobsPageUpdate()
 }
 
 func (h *graphRunEventHandler) OnUpdate(oldObj, newObj interface{}) {
@@ -181,6 +185,7 @@ func (h *graphRunEventHandler) OnUpdate(oldObj, newObj interface{}) {
 		"completedNodes", newRun.Status.Summary.CompletedNodes)
 
 	h.broadcaster.BroadcastGraphRunUpdate(newRun, "updated")
+	h.broadcaster.BroadcastJobsPageUpdate()
 }
 
 func (h *graphRunEventHandler) OnDelete(obj interface{}) {
@@ -203,6 +208,7 @@ func (h *graphRunEventHandler) OnDelete(obj interface{}) {
 
 	h.logger.V(1).Info("GraphRun deleted", "name", run.Name)
 	h.broadcaster.BroadcastGraphRunDeleted(run)
+	h.broadcaster.BroadcastJobsPageUpdate()
 }
 
 // hasScenarioRunStatusChanged checks if ScenarioRun status has meaningful changes


### PR DESCRIPTION
## Summary

- Add new `GET /api/v2/jobs` REST endpoint that merges standalone ScenarioRuns + GraphRuns into a unified paginated list sorted by creation time DESC
- Add `"jobs"` WebSocket resource type: clients subscribe with `page`/`limit` and receive page-level snapshots with FNV-1a fingerprint deduplication
- Default page size configurable via ConfigMap key `jobs.defaultPageSize`, env var `KRKN_JOBS_DEFAULT_PAGE_SIZE`, or defaults to 20
- Extract generic `PaginateSlice[T]` and `ParsePaginationParams` utilities, refactor existing user pagination to use them
- Graph-run children (label `krkn.dev/graph-run`) are excluded from the unified list

## Details

### REST API
- `GET /api/v2/jobs` — returns all jobs (unpaginated) when no `page` query param
- `GET /api/v2/jobs?page=1&limit=20` — returns paginated response with `PaginationMeta` (page, limit, total, totalPages)
- Group-based authorization filtering applied per user

### WebSocket
- Subscribe: `{ action: "subscribe", resource: "jobs", page: 1, limit: 20 }`
- Server sends `{ resource: "jobs", event: "snapshot", data: { jobs: [...] }, pagination: {...} }`
- On any ScenarioRun/GraphRun add/update/delete, server recomputes the client's page and sends only if content changed
- Existing `"run"` and `"graphrun"` subscriptions unchanged (backward compatible)

### Configuration
- `jobs.defaultPageSize` in `krkn-operator-config` ConfigMap
- `KRKN_JOBS_DEFAULT_PAGE_SIZE` env var (overrides ConfigMap)
- Fallback: 20

## Test plan

- [x] 8 unit tests for generic pagination (`PaginateSlice`, `ParsePaginationParams`)
- [x] 6 unit tests for REST handler (`ListJobs`: no pagination, paginated, empty, graph-run children filtered, type discriminator, sort order)
- [x] 7 unit tests for WebSocket (`JobsSubscribe`, defaults, `SendJobsSnapshot`, `BroadcastJobsPageUpdate`, dedup, `BuildUnifiedJobList`, `PaginateJobItems`)
- [x] All existing tests pass (e2e excluded — requires live cluster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)