### PR TITLE
feat(api): add cloud provider credential management

### DIFF
--- a/api/v1alpha1/krkngraphrun_types.go
+++ b/api/v1alpha1/krkngraphrun_types.go
@@ -73,6 +73,10 @@ type GraphScenarioNode struct {
 	// DependsOn is the node ID that this scenario depends on (parent in the graph)
 	// +optional
 	DependsOn *string `json:"depends_on,omitempty"`
+
+	// CloudCredentialRef overrides the graph-level cloud credential for this specific node
+	// +optional
+	CloudCredentialRef string `json:"cloudCredentialRef,omitempty"`
 }
 
 // NodeStatus represents the status of a single node in the dependency graph
@@ -197,6 +201,10 @@ type KrknGraphRunSpec struct {
 	// OwnerUserID is the email address of the user who created this graph run
 	// +optional
 	OwnerUserID string `json:"ownerUserId,omitempty"`
+
+	// CloudCredentialRef is the default cloud credential for all nodes in this graph run
+	// +optional
+	CloudCredentialRef string `json:"cloudCredentialRef,omitempty"`
 
 	// ResiliencyScoreEnabled enables resiliency score calculation for this graph run.
 	// When enabled:

--- a/api/v1alpha1/krknscenariorun_types.go
+++ b/api/v1alpha1/krknscenariorun_types.go
@@ -148,6 +148,10 @@ type KrknScenarioRunSpec struct {
 	// +optional
 	RegistryName string `json:"registryName,omitempty"`
 
+	// CloudCredentialRef is the name of the cloud credential Secret to inject into the scenario pod
+	// +optional
+	CloudCredentialRef string `json:"cloudCredentialRef,omitempty"`
+
 	// MaxRetries is the maximum number of times to retry failed jobs
 	// +optional
 	// +kubebuilder:default=3

--- a/config/crd/bases/krkn.krkn-chaos.dev_krkngraphruns.yaml
+++ b/config/crd/bases/krkn.krkn-chaos.dev_krkngraphruns.yaml
@@ -57,6 +57,10 @@ spec:
           spec:
             description: KrknGraphRunSpec defines the desired state of KrknGraphRun
             properties:
+              cloudCredentialRef:
+                description: CloudCredentialRef is the default cloud credential for
+                  all nodes in this graph run
+                type: string
               graph:
                 additionalProperties:
                   description: |-
@@ -65,6 +69,10 @@ spec:
                   properties:
                     _comment:
                       description: Comment is an optional comment describing the scenario
+                      type: string
+                    cloudCredentialRef:
+                      description: CloudCredentialRef overrides the graph-level cloud
+                        credential for this specific node
                       type: string
                     depends_on:
                       description: DependsOn is the node ID that this scenario depends

--- a/config/crd/bases/krkn.krkn-chaos.dev_krknscenarioruns.yaml
+++ b/config/crd/bases/krkn.krkn-chaos.dev_krknscenarioruns.yaml
@@ -57,6 +57,10 @@ spec:
           spec:
             description: KrknScenarioRunSpec defines the desired state of KrknScenarioRun
             properties:
+              cloudCredentialRef:
+                description: CloudCredentialRef is the name of the cloud credential
+                  Secret to inject into the scenario pod
+                type: string
               customRunName:
                 description: CustomRunName is a user-provided label for the run, displayed
                   in the console

--- a/internal/api/cloudcreds_handlers.go
+++ b/internal/api/cloudcreds_handlers.go
@@ -539,6 +539,10 @@ func buildCloudCredentialSecretData(req *cloudcreds.CreateCloudCredentialRequest
 		if req.OSDomainName != "" {
 			data[cloudcreds.SecretKeyOSDomainName] = []byte(req.OSDomainName)
 		}
+	case cloudcreds.ProviderBaremetal:
+		data[cloudcreds.SecretKeyBMCUser] = []byte(req.BMCUser)
+		data[cloudcreds.SecretKeyBMCPassword] = []byte(req.BMCPassword)
+		data[cloudcreds.SecretKeyBMCAddr] = []byte(req.BMCAddr)
 	}
 
 	return data
@@ -590,6 +594,16 @@ func updateCloudCredentialSecretData(secret *corev1.Secret, provider string, req
 		}
 		if req.OSDomainName != "" {
 			secret.Data[cloudcreds.SecretKeyOSDomainName] = []byte(req.OSDomainName)
+		}
+	case cloudcreds.ProviderBaremetal:
+		if req.BMCUser != "" {
+			secret.Data[cloudcreds.SecretKeyBMCUser] = []byte(req.BMCUser)
+		}
+		if req.BMCPassword != "" {
+			secret.Data[cloudcreds.SecretKeyBMCPassword] = []byte(req.BMCPassword)
+		}
+		if req.BMCAddr != "" {
+			secret.Data[cloudcreds.SecretKeyBMCAddr] = []byte(req.BMCAddr)
 		}
 	}
 }

--- a/internal/api/cloudcreds_handlers.go
+++ b/internal/api/cloudcreds_handlers.go
@@ -543,6 +543,13 @@ func buildCloudCredentialSecretData(req *cloudcreds.CreateCloudCredentialRequest
 		data[cloudcreds.SecretKeyBMCUser] = []byte(req.BMCUser)
 		data[cloudcreds.SecretKeyBMCPassword] = []byte(req.BMCPassword)
 		data[cloudcreds.SecretKeyBMCAddr] = []byte(req.BMCAddr)
+	case cloudcreds.ProviderVMware:
+		data[cloudcreds.SecretKeyVSphereIP] = []byte(req.VSphereIP)
+		data[cloudcreds.SecretKeyVSphereUsername] = []byte(req.VSphereUsername)
+		data[cloudcreds.SecretKeyVSpherePassword] = []byte(req.VSpherePassword)
+	case cloudcreds.ProviderIBMCloud:
+		data[cloudcreds.SecretKeyIBMCURL] = []byte(req.IBMCURL)
+		data[cloudcreds.SecretKeyIBMCAPIKey] = []byte(req.IBMCAPIKey)
 	}
 
 	return data
@@ -604,6 +611,23 @@ func updateCloudCredentialSecretData(secret *corev1.Secret, provider string, req
 		}
 		if req.BMCAddr != "" {
 			secret.Data[cloudcreds.SecretKeyBMCAddr] = []byte(req.BMCAddr)
+		}
+	case cloudcreds.ProviderVMware:
+		if req.VSphereIP != "" {
+			secret.Data[cloudcreds.SecretKeyVSphereIP] = []byte(req.VSphereIP)
+		}
+		if req.VSphereUsername != "" {
+			secret.Data[cloudcreds.SecretKeyVSphereUsername] = []byte(req.VSphereUsername)
+		}
+		if req.VSpherePassword != "" {
+			secret.Data[cloudcreds.SecretKeyVSpherePassword] = []byte(req.VSpherePassword)
+		}
+	case cloudcreds.ProviderIBMCloud:
+		if req.IBMCURL != "" {
+			secret.Data[cloudcreds.SecretKeyIBMCURL] = []byte(req.IBMCURL)
+		}
+		if req.IBMCAPIKey != "" {
+			secret.Data[cloudcreds.SecretKeyIBMCAPIKey] = []byte(req.IBMCAPIKey)
 		}
 	}
 }

--- a/internal/api/cloudcreds_handlers.go
+++ b/internal/api/cloudcreds_handlers.go
@@ -1,0 +1,595 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/krkn-chaos/krkn-operator/pkg/auth"
+	"github.com/krkn-chaos/krkn-operator/pkg/cloudcreds"
+	"github.com/krkn-chaos/krkn-operator/pkg/groupauth"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// CreateCloudCredential handles POST /api/v1/cloud-credentials
+func (h *Handler) CreateCloudCredential(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	logger := log.FromContext(ctx).WithName("create-cloud-credential")
+
+	if !auth.IsAdmin(ctx) {
+		writeJSONError(w, http.StatusForbidden, ErrorResponse{
+			Error:   "forbidden",
+			Message: "This operation requires admin privileges",
+		})
+		return
+	}
+
+	var req cloudcreds.CreateCloudCredentialRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, ErrorResponse{
+			Error:   "bad_request",
+			Message: "Invalid request body: " + err.Error(),
+		})
+		return
+	}
+
+	if err := cloudcreds.ValidateCreateRequest(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, ErrorResponse{
+			Error:   "bad_request",
+			Message: err.Error(),
+		})
+		return
+	}
+
+	exists, err := h.cloudCredentialExists(ctx, req.Name)
+	if err != nil {
+		logger.Error(err, "Failed to check for existing cloud credential", "name", req.Name)
+		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
+			Error:   "internal_error",
+			Message: "Failed to check for existing cloud credential",
+		})
+		return
+	}
+	if exists {
+		writeJSONError(w, http.StatusBadRequest, ErrorResponse{
+			Error:   "bad_request",
+			Message: fmt.Sprintf("Cloud credential '%s' already exists", req.Name),
+		})
+		return
+	}
+
+	claims := auth.GetClaimsFromContext(ctx)
+	createdBy := ""
+	if claims != nil {
+		createdBy = claims.UserID
+	}
+
+	labels := cloudcreds.BuildLabels(req.Provider, req.Groups, req.AvailableToAll)
+	annotations := cloudcreds.BuildAnnotations(req.Description, createdBy)
+	data := buildCloudCredentialSecretData(&req)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        req.Name,
+			Namespace:   h.namespace,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: data,
+	}
+
+	if err := h.client.Create(ctx, secret); err != nil {
+		logger.Error(err, "Failed to create cloud credential secret", "name", req.Name)
+		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
+			Error:   "internal_error",
+			Message: "Failed to create cloud credential",
+		})
+		return
+	}
+
+	logger.Info("Created cloud credential", "name", req.Name, "provider", req.Provider, "createdBy", createdBy)
+
+	writeJSON(w, http.StatusCreated, cloudcreds.CreateCloudCredentialResponse{
+		Message: "Cloud credential created successfully",
+		Name:    req.Name,
+	})
+}
+
+// ListCloudCredentials handles GET /api/v1/cloud-credentials
+func (h *Handler) ListCloudCredentials(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	logger := log.FromContext(ctx).WithName("list-cloud-credentials")
+
+	if !auth.IsAdmin(ctx) {
+		writeJSONError(w, http.StatusForbidden, ErrorResponse{
+			Error:   "forbidden",
+			Message: "This operation requires admin privileges",
+		})
+		return
+	}
+
+	var secretList corev1.SecretList
+	if err := h.client.List(ctx, &secretList,
+		client.InNamespace(h.namespace),
+		client.MatchingLabels{
+			cloudcreds.AppNameLabel:      cloudcreds.AppName,
+			cloudcreds.AppComponentLabel: cloudcreds.ComponentCloudCredential,
+		},
+	); err != nil {
+		logger.Error(err, "Failed to list cloud credential secrets")
+		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
+			Error:   "internal_error",
+			Message: "Failed to list cloud credentials",
+		})
+		return
+	}
+
+	credentials := make([]cloudcreds.CloudCredentialResponse, len(secretList.Items))
+	for i, secret := range secretList.Items {
+		credentials[i] = buildCloudCredentialResponse(&secret)
+	}
+
+	logger.Info("Listed cloud credentials", "total", len(credentials))
+
+	writeJSON(w, http.StatusOK, cloudcreds.ListCloudCredentialsResponse{
+		Credentials: credentials,
+		Total:       len(credentials),
+	})
+}
+
+// GetCloudCredential handles GET /api/v1/cloud-credentials/{name}
+func (h *Handler) GetCloudCredential(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	logger := log.FromContext(ctx).WithName("get-cloud-credential")
+
+	if !auth.IsAdmin(ctx) {
+		writeJSONError(w, http.StatusForbidden, ErrorResponse{
+			Error:   "forbidden",
+			Message: "This operation requires admin privileges",
+		})
+		return
+	}
+
+	credName, err := extractPathSuffix(r.URL.Path, CloudCredentialsPath+"/")
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, ErrorResponse{
+			Error:   "bad_request",
+			Message: "Invalid credential name in path",
+		})
+		return
+	}
+
+	secret, err := h.loadCloudCredentialSecret(ctx, credName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			writeJSONError(w, http.StatusNotFound, ErrorResponse{
+				Error:   "not_found",
+				Message: fmt.Sprintf("Cloud credential '%s' not found", credName),
+			})
+		} else {
+			logger.Error(err, "Failed to get cloud credential", "name", credName)
+			writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
+				Error:   "internal_error",
+				Message: "Failed to get cloud credential",
+			})
+		}
+		return
+	}
+
+	logger.Info("Retrieved cloud credential", "name", credName)
+	writeJSON(w, http.StatusOK, buildCloudCredentialResponse(secret))
+}
+
+// UpdateCloudCredential handles PUT /api/v1/cloud-credentials/{name}
+func (h *Handler) UpdateCloudCredential(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	logger := log.FromContext(ctx).WithName("update-cloud-credential")
+
+	if !auth.IsAdmin(ctx) {
+		writeJSONError(w, http.StatusForbidden, ErrorResponse{
+			Error:   "forbidden",
+			Message: "This operation requires admin privileges",
+		})
+		return
+	}
+
+	credName, err := extractPathSuffix(r.URL.Path, CloudCredentialsPath+"/")
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, ErrorResponse{
+			Error:   "bad_request",
+			Message: "Invalid credential name in path",
+		})
+		return
+	}
+
+	var req cloudcreds.UpdateCloudCredentialRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, ErrorResponse{
+			Error:   "bad_request",
+			Message: "Invalid request body: " + err.Error(),
+		})
+		return
+	}
+
+	secret, err := h.loadCloudCredentialSecret(ctx, credName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			writeJSONError(w, http.StatusNotFound, ErrorResponse{
+				Error:   "not_found",
+				Message: fmt.Sprintf("Cloud credential '%s' not found", credName),
+			})
+		} else {
+			logger.Error(err, "Failed to get cloud credential", "name", credName)
+			writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
+				Error:   "internal_error",
+				Message: "Failed to get cloud credential",
+			})
+		}
+		return
+	}
+
+	existingProvider := secret.Labels[cloudcreds.ProviderTypeLabel]
+	if err := cloudcreds.ValidateUpdateRequest(&req, existingProvider); err != nil {
+		writeJSONError(w, http.StatusBadRequest, ErrorResponse{
+			Error:   "bad_request",
+			Message: err.Error(),
+		})
+		return
+	}
+
+	claims := auth.GetClaimsFromContext(ctx)
+	updatedBy := ""
+	if claims != nil {
+		updatedBy = claims.UserID
+	}
+
+	secret.Annotations = cloudcreds.UpdateAnnotations(secret.Annotations, req.Description, updatedBy)
+	secret.Labels = cloudcreds.BuildLabels(existingProvider, req.Groups, req.AvailableToAll)
+
+	if secret.Data == nil {
+		secret.Data = make(map[string][]byte)
+	}
+	updateCloudCredentialSecretData(secret, existingProvider, &req)
+
+	if err := h.client.Update(ctx, secret); err != nil {
+		logger.Error(err, "Failed to update cloud credential", "name", credName)
+		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
+			Error:   "internal_error",
+			Message: "Failed to update cloud credential",
+		})
+		return
+	}
+
+	logger.Info("Updated cloud credential", "name", credName, "updatedBy", updatedBy)
+
+	writeJSON(w, http.StatusOK, cloudcreds.UpdateCloudCredentialResponse{
+		Message: "Cloud credential updated successfully",
+		Name:    credName,
+	})
+}
+
+// DeleteCloudCredential handles DELETE /api/v1/cloud-credentials/{name}
+func (h *Handler) DeleteCloudCredential(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	logger := log.FromContext(ctx).WithName("delete-cloud-credential")
+
+	if !auth.IsAdmin(ctx) {
+		writeJSONError(w, http.StatusForbidden, ErrorResponse{
+			Error:   "forbidden",
+			Message: "This operation requires admin privileges",
+		})
+		return
+	}
+
+	credName, err := extractPathSuffix(r.URL.Path, CloudCredentialsPath+"/")
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, ErrorResponse{
+			Error:   "bad_request",
+			Message: "Invalid credential name in path",
+		})
+		return
+	}
+
+	secret, err := h.loadCloudCredentialSecret(ctx, credName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			writeJSONError(w, http.StatusNotFound, ErrorResponse{
+				Error:   "not_found",
+				Message: fmt.Sprintf("Cloud credential '%s' not found", credName),
+			})
+		} else {
+			logger.Error(err, "Failed to get cloud credential", "name", credName)
+			writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
+				Error:   "internal_error",
+				Message: "Failed to get cloud credential",
+			})
+		}
+		return
+	}
+
+	if err := h.client.Delete(ctx, secret); err != nil {
+		logger.Error(err, "Failed to delete cloud credential", "name", credName)
+		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
+			Error:   "internal_error",
+			Message: "Failed to delete cloud credential",
+		})
+		return
+	}
+
+	logger.Info("Deleted cloud credential", "name", credName)
+
+	writeJSON(w, http.StatusOK, cloudcreds.DeleteCloudCredentialResponse{
+		Message: "Cloud credential deleted successfully",
+	})
+}
+
+// ListAvailableCloudCredentials handles GET /api/v1/cloud-credentials/available
+func (h *Handler) ListAvailableCloudCredentials(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	logger := log.FromContext(ctx).WithName("list-available-cloud-credentials")
+
+	var secretList corev1.SecretList
+	if err := h.client.List(ctx, &secretList,
+		client.InNamespace(h.namespace),
+		client.MatchingLabels{
+			cloudcreds.AppNameLabel:      cloudcreds.AppName,
+			cloudcreds.AppComponentLabel: cloudcreds.ComponentCloudCredential,
+		},
+	); err != nil {
+		logger.Error(err, "Failed to list cloud credential secrets")
+		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
+			Error:   "internal_error",
+			Message: "Failed to list cloud credentials",
+		})
+		return
+	}
+
+	var credentials []cloudcreds.CloudCredentialResponse
+	for i := range secretList.Items {
+		if h.canAccessCloudCredential(ctx, &secretList.Items[i]) {
+			credentials = append(credentials, buildCloudCredentialResponse(&secretList.Items[i]))
+		}
+	}
+
+	if credentials == nil {
+		credentials = []cloudcreds.CloudCredentialResponse{}
+	}
+
+	logger.Info("Listed available cloud credentials", "total", len(credentials))
+
+	writeJSON(w, http.StatusOK, cloudcreds.ListCloudCredentialsResponse{
+		Credentials: credentials,
+		Total:       len(credentials),
+	})
+}
+
+// CloudCredentialsRouter routes requests to /api/v1/cloud-credentials endpoints
+func (h *Handler) CloudCredentialsRouter(w http.ResponseWriter, r *http.Request) {
+	path := r.URL.Path
+	normalizedPath := strings.TrimSuffix(path, "/")
+
+	if normalizedPath == CloudCredentialsPath {
+		switch r.Method {
+		case http.MethodGet:
+			h.ListCloudCredentials(w, r)
+		case http.MethodPost:
+			h.CreateCloudCredential(w, r)
+		default:
+			writeJSONError(w, http.StatusMethodNotAllowed, ErrorResponse{
+				Error:   "method_not_allowed",
+				Message: "Only GET and POST are allowed on " + CloudCredentialsPath,
+			})
+		}
+		return
+	}
+
+	if strings.HasPrefix(path, CloudCredentialsPath+"/") {
+		switch r.Method {
+		case http.MethodGet:
+			h.GetCloudCredential(w, r)
+		case http.MethodPut:
+			h.UpdateCloudCredential(w, r)
+		case http.MethodDelete:
+			h.DeleteCloudCredential(w, r)
+		default:
+			writeJSONError(w, http.StatusMethodNotAllowed, ErrorResponse{
+				Error:   "method_not_allowed",
+				Message: "Invalid method for cloud credential endpoint",
+			})
+		}
+		return
+	}
+
+	writeJSONError(w, http.StatusNotFound, ErrorResponse{
+		Error:   "not_found",
+		Message: "Endpoint not found",
+	})
+}
+
+// cloudCredentialExists checks whether a cloud credential Secret exists
+func (h *Handler) cloudCredentialExists(ctx context.Context, name string) (bool, error) {
+	var secret corev1.Secret
+	err := h.client.Get(ctx, types.NamespacedName{
+		Name:      name,
+		Namespace: h.namespace,
+	}, &secret)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return secret.Labels[cloudcreds.AppComponentLabel] == cloudcreds.ComponentCloudCredential, nil
+}
+
+// loadCloudCredentialSecret loads a cloud credential Secret by name
+func (h *Handler) loadCloudCredentialSecret(ctx context.Context, name string) (*corev1.Secret, error) {
+	var secret corev1.Secret
+	if err := h.client.Get(ctx, types.NamespacedName{
+		Name:      name,
+		Namespace: h.namespace,
+	}, &secret); err != nil {
+		return nil, err
+	}
+
+	if secret.Labels[cloudcreds.AppComponentLabel] != cloudcreds.ComponentCloudCredential {
+		return nil, fmt.Errorf("secret is not a cloud credential secret")
+	}
+
+	return &secret, nil
+}
+
+// canAccessCloudCredential checks if the current user can access a cloud credential
+func (h *Handler) canAccessCloudCredential(ctx context.Context, secret *corev1.Secret) bool {
+	claims := auth.GetClaimsFromContext(ctx)
+	if claims == nil {
+		return false
+	}
+
+	if auth.IsAdmin(ctx) {
+		return true
+	}
+
+	if secret.Labels[cloudcreds.AvailableToAllLabel] == "true" {
+		return true
+	}
+
+	userGroups, err := groupauth.GetUserGroups(ctx, h.client, claims.UserID, h.namespace)
+	if err != nil {
+		return false
+	}
+
+	secretGroups := cloudcreds.ExtractGroupsFromLabels(secret.Labels)
+
+	userGroupNames := make(map[string]bool)
+	for _, ug := range userGroups {
+		userGroupNames[ug.Name] = true
+	}
+
+	for _, sg := range secretGroups {
+		if userGroupNames[sg] {
+			return true
+		}
+	}
+
+	return false
+}
+
+// buildCloudCredentialResponse constructs a CloudCredentialResponse from a Secret.
+// Secret data is intentionally never included.
+func buildCloudCredentialResponse(secret *corev1.Secret) cloudcreds.CloudCredentialResponse {
+	return cloudcreds.CloudCredentialResponse{
+		Name:           secret.Name,
+		Provider:       secret.Labels[cloudcreds.ProviderTypeLabel],
+		Description:    secret.Annotations[cloudcreds.DescriptionAnnotation],
+		Groups:         cloudcreds.ExtractGroupsFromLabels(secret.Labels),
+		AvailableToAll: secret.Labels[cloudcreds.AvailableToAllLabel] == "true",
+		CreatedAt:      secret.Annotations[cloudcreds.CreatedAtAnnotation],
+		CreatedBy:      secret.Annotations[cloudcreds.CreatedByAnnotation],
+		UpdatedAt:      secret.Annotations[cloudcreds.UpdatedAtAnnotation],
+		UpdatedBy:      secret.Annotations[cloudcreds.UpdatedByAnnotation],
+	}
+}
+
+// buildCloudCredentialSecretData creates the Secret.Data map from a create request
+func buildCloudCredentialSecretData(req *cloudcreds.CreateCloudCredentialRequest) map[string][]byte {
+	data := make(map[string][]byte)
+
+	switch req.Provider {
+	case cloudcreds.ProviderAWS:
+		data[cloudcreds.SecretKeyAWSAccessKeyID] = []byte(req.AWSAccessKeyID)
+		data[cloudcreds.SecretKeyAWSSecretAccessKey] = []byte(req.AWSSecretAccessKey)
+		data[cloudcreds.SecretKeyAWSDefaultRegion] = []byte(req.AWSDefaultRegion)
+	case cloudcreds.ProviderGCP:
+		data[cloudcreds.SecretKeyGCPServiceAccountJSON] = []byte(req.GCPServiceAccountJSON)
+	case cloudcreds.ProviderAzure:
+		data[cloudcreds.SecretKeyAzureTenantID] = []byte(req.AzureTenantID)
+		data[cloudcreds.SecretKeyAzureClientID] = []byte(req.AzureClientID)
+		data[cloudcreds.SecretKeyAzureClientSecret] = []byte(req.AzureClientSecret)
+		data[cloudcreds.SecretKeyAzureSubscriptionID] = []byte(req.AzureSubscriptionID)
+	case cloudcreds.ProviderOpenStack:
+		data[cloudcreds.SecretKeyOSAuthURL] = []byte(req.OSAuthURL)
+		data[cloudcreds.SecretKeyOSUsername] = []byte(req.OSUsername)
+		data[cloudcreds.SecretKeyOSPassword] = []byte(req.OSPassword)
+		data[cloudcreds.SecretKeyOSProjectName] = []byte(req.OSProjectName)
+		if req.OSDomainName != "" {
+			data[cloudcreds.SecretKeyOSDomainName] = []byte(req.OSDomainName)
+		}
+	}
+
+	return data
+}
+
+// updateCloudCredentialSecretData updates Secret.Data fields from an update request.
+// Empty strings mean "keep existing value".
+func updateCloudCredentialSecretData(secret *corev1.Secret, provider string, req *cloudcreds.UpdateCloudCredentialRequest) {
+	switch provider {
+	case cloudcreds.ProviderAWS:
+		if req.AWSAccessKeyID != "" {
+			secret.Data[cloudcreds.SecretKeyAWSAccessKeyID] = []byte(req.AWSAccessKeyID)
+		}
+		if req.AWSSecretAccessKey != "" {
+			secret.Data[cloudcreds.SecretKeyAWSSecretAccessKey] = []byte(req.AWSSecretAccessKey)
+		}
+		if req.AWSDefaultRegion != "" {
+			secret.Data[cloudcreds.SecretKeyAWSDefaultRegion] = []byte(req.AWSDefaultRegion)
+		}
+	case cloudcreds.ProviderGCP:
+		if req.GCPServiceAccountJSON != "" {
+			secret.Data[cloudcreds.SecretKeyGCPServiceAccountJSON] = []byte(req.GCPServiceAccountJSON)
+		}
+	case cloudcreds.ProviderAzure:
+		if req.AzureTenantID != "" {
+			secret.Data[cloudcreds.SecretKeyAzureTenantID] = []byte(req.AzureTenantID)
+		}
+		if req.AzureClientID != "" {
+			secret.Data[cloudcreds.SecretKeyAzureClientID] = []byte(req.AzureClientID)
+		}
+		if req.AzureClientSecret != "" {
+			secret.Data[cloudcreds.SecretKeyAzureClientSecret] = []byte(req.AzureClientSecret)
+		}
+		if req.AzureSubscriptionID != "" {
+			secret.Data[cloudcreds.SecretKeyAzureSubscriptionID] = []byte(req.AzureSubscriptionID)
+		}
+	case cloudcreds.ProviderOpenStack:
+		if req.OSAuthURL != "" {
+			secret.Data[cloudcreds.SecretKeyOSAuthURL] = []byte(req.OSAuthURL)
+		}
+		if req.OSUsername != "" {
+			secret.Data[cloudcreds.SecretKeyOSUsername] = []byte(req.OSUsername)
+		}
+		if req.OSPassword != "" {
+			secret.Data[cloudcreds.SecretKeyOSPassword] = []byte(req.OSPassword)
+		}
+		if req.OSProjectName != "" {
+			secret.Data[cloudcreds.SecretKeyOSProjectName] = []byte(req.OSProjectName)
+		}
+		if req.OSDomainName != "" {
+			secret.Data[cloudcreds.SecretKeyOSDomainName] = []byte(req.OSDomainName)
+		}
+	}
+}

--- a/internal/api/cloudcreds_handlers.go
+++ b/internal/api/cloudcreds_handlers.go
@@ -65,23 +65,6 @@ func (h *Handler) CreateCloudCredential(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	exists, err := h.cloudCredentialExists(ctx, req.Name)
-	if err != nil {
-		logger.Error(err, "Failed to check for existing cloud credential", "name", req.Name)
-		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
-			Error:   "internal_error",
-			Message: "Failed to check for existing cloud credential",
-		})
-		return
-	}
-	if exists {
-		writeJSONError(w, http.StatusConflict, ErrorResponse{
-			Error:   "conflict",
-			Message: fmt.Sprintf("A secret named '%s' already exists", req.Name),
-		})
-		return
-	}
-
 	claims := auth.GetClaimsFromContext(ctx)
 	createdBy := ""
 	if claims != nil {
@@ -104,6 +87,13 @@ func (h *Handler) CreateCloudCredential(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if err := h.client.Create(ctx, secret); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			writeJSONError(w, http.StatusConflict, ErrorResponse{
+				Error:   "conflict",
+				Message: fmt.Sprintf("A secret named '%s' already exists", req.Name),
+			})
+			return
+		}
 		logger.Error(err, "Failed to create cloud credential secret", "name", req.Name)
 		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
 			Error:   "internal_error",

--- a/internal/api/cloudcreds_handlers.go
+++ b/internal/api/cloudcreds_handlers.go
@@ -18,6 +18,7 @@ package api
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -74,9 +75,9 @@ func (h *Handler) CreateCloudCredential(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	if exists {
-		writeJSONError(w, http.StatusBadRequest, ErrorResponse{
-			Error:   "bad_request",
-			Message: fmt.Sprintf("Cloud credential '%s' already exists", req.Name),
+		writeJSONError(w, http.StatusConflict, ErrorResponse{
+			Error:   "conflict",
+			Message: fmt.Sprintf("A secret named '%s' already exists", req.Name),
 		})
 		return
 	}
@@ -370,7 +371,12 @@ func (h *Handler) ListAvailableCloudCredentials(w http.ResponseWriter, r *http.R
 
 	var credentials []cloudcreds.CloudCredentialResponse
 	for i := range secretList.Items {
-		if h.canAccessCloudCredential(ctx, &secretList.Items[i]) {
+		allowed, err := h.canAccessCloudCredential(ctx, &secretList.Items[i])
+		if err != nil {
+			logger.Error(err, "Failed to check access for cloud credential", "name", secretList.Items[i].Name)
+			continue
+		}
+		if allowed {
 			credentials = append(credentials, buildCloudCredentialResponse(&secretList.Items[i]))
 		}
 	}
@@ -430,7 +436,9 @@ func (h *Handler) CloudCredentialsRouter(w http.ResponseWriter, r *http.Request)
 	})
 }
 
-// cloudCredentialExists checks whether a cloud credential Secret exists
+// cloudCredentialExists checks whether a Secret with the given name exists.
+// Returns true if ANY Secret with that name exists (not just cloud credentials),
+// to prevent AlreadyExists errors when creating.
 func (h *Handler) cloudCredentialExists(ctx context.Context, name string) (bool, error) {
 	var secret corev1.Secret
 	err := h.client.Get(ctx, types.NamespacedName{
@@ -443,7 +451,7 @@ func (h *Handler) cloudCredentialExists(ctx context.Context, name string) (bool,
 		}
 		return false, err
 	}
-	return secret.Labels[cloudcreds.AppComponentLabel] == cloudcreds.ComponentCloudCredential, nil
+	return true, nil
 }
 
 // loadCloudCredentialSecret loads a cloud credential Secret by name
@@ -463,24 +471,25 @@ func (h *Handler) loadCloudCredentialSecret(ctx context.Context, name string) (*
 	return &secret, nil
 }
 
-// canAccessCloudCredential checks if the current user can access a cloud credential
-func (h *Handler) canAccessCloudCredential(ctx context.Context, secret *corev1.Secret) bool {
+// canAccessCloudCredential checks if the current user can access a cloud credential.
+// Returns (allowed, error) so callers can distinguish access denial from internal failures.
+func (h *Handler) canAccessCloudCredential(ctx context.Context, secret *corev1.Secret) (bool, error) {
 	claims := auth.GetClaimsFromContext(ctx)
 	if claims == nil {
-		return false
+		return false, nil
 	}
 
 	if auth.IsAdmin(ctx) {
-		return true
+		return true, nil
 	}
 
 	if secret.Labels[cloudcreds.AvailableToAllLabel] == "true" {
-		return true
+		return true, nil
 	}
 
 	userGroups, err := groupauth.GetUserGroups(ctx, h.client, claims.UserID, h.namespace)
 	if err != nil {
-		return false
+		return false, fmt.Errorf("failed to check group membership: %w", err)
 	}
 
 	secretGroups := cloudcreds.ExtractGroupsFromLabels(secret.Labels)
@@ -492,11 +501,11 @@ func (h *Handler) canAccessCloudCredential(ctx context.Context, secret *corev1.S
 
 	for _, sg := range secretGroups {
 		if userGroupNames[sg] {
-			return true
+			return true, nil
 		}
 	}
 
-	return false
+	return false, nil
 }
 
 // buildCloudCredentialResponse constructs a CloudCredentialResponse from a Secret.
@@ -525,7 +534,8 @@ func buildCloudCredentialSecretData(req *cloudcreds.CreateCloudCredentialRequest
 		data[cloudcreds.SecretKeyAWSSecretAccessKey] = []byte(req.AWSSecretAccessKey)
 		data[cloudcreds.SecretKeyAWSDefaultRegion] = []byte(req.AWSDefaultRegion)
 	case cloudcreds.ProviderGCP:
-		data[cloudcreds.SecretKeyGCPServiceAccountJSON] = []byte(req.GCPServiceAccountJSON)
+		decoded, _ := base64.StdEncoding.DecodeString(req.GCPServiceAccountJSON)
+		data[cloudcreds.SecretKeyGCPServiceAccountJSON] = decoded
 	case cloudcreds.ProviderAzure:
 		data[cloudcreds.SecretKeyAzureTenantID] = []byte(req.AzureTenantID)
 		data[cloudcreds.SecretKeyAzureClientID] = []byte(req.AzureClientID)
@@ -571,7 +581,8 @@ func updateCloudCredentialSecretData(secret *corev1.Secret, provider string, req
 		}
 	case cloudcreds.ProviderGCP:
 		if req.GCPServiceAccountJSON != "" {
-			secret.Data[cloudcreds.SecretKeyGCPServiceAccountJSON] = []byte(req.GCPServiceAccountJSON)
+			decoded, _ := base64.StdEncoding.DecodeString(req.GCPServiceAccountJSON)
+			secret.Data[cloudcreds.SecretKeyGCPServiceAccountJSON] = decoded
 		}
 	case cloudcreds.ProviderAzure:
 		if req.AzureTenantID != "" {

--- a/internal/api/cloudcreds_handlers_test.go
+++ b/internal/api/cloudcreds_handlers_test.go
@@ -1,0 +1,627 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/krkn-chaos/krkn-operator/pkg/cloudcreds"
+)
+
+func newCloudCredScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	return scheme
+}
+
+func newAWSTestSecret(name, namespace string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Labels:      cloudcreds.BuildLabels(cloudcreds.ProviderAWS, nil, false),
+			Annotations: cloudcreds.BuildAnnotations("test aws creds", "admin@test.local"),
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			cloudcreds.SecretKeyAWSAccessKeyID:     []byte("AKIATEST"),
+			cloudcreds.SecretKeyAWSSecretAccessKey: []byte("secret"),
+			cloudcreds.SecretKeyAWSDefaultRegion:   []byte("us-east-1"),
+		},
+	}
+}
+
+func newGCPTestSecret(name, namespace string) *corev1.Secret {
+	decoded := []byte(`{"type":"service_account","project_id":"test-project"}`)
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Labels:      cloudcreds.BuildLabels(cloudcreds.ProviderGCP, nil, true),
+			Annotations: cloudcreds.BuildAnnotations("test gcp creds", "admin@test.local"),
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			cloudcreds.SecretKeyGCPServiceAccountJSON: decoded,
+		},
+	}
+}
+
+func newGroupedAWSSecret(name, namespace string, groups []string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Labels:      cloudcreds.BuildLabels(cloudcreds.ProviderAWS, groups, false),
+			Annotations: cloudcreds.BuildAnnotations("grouped aws", "admin@test.local"),
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			cloudcreds.SecretKeyAWSAccessKeyID:     []byte("AKIATEST"),
+			cloudcreds.SecretKeyAWSSecretAccessKey: []byte("secret"),
+			cloudcreds.SecretKeyAWSDefaultRegion:   []byte("us-east-1"),
+		},
+	}
+}
+
+// ── CreateCloudCredential ───────────────────────────────────────────────────
+
+func TestCreateCloudCredential_AWS_Success(t *testing.T) {
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(newCloudCredScheme()).Build()
+	handler := NewTestHandler(fakeClient, fake.NewSimpleClientset(), "default", "localhost:50051")
+
+	body := cloudcreds.CreateCloudCredentialRequest{
+		Name:               "aws-prod",
+		Provider:           cloudcreds.ProviderAWS,
+		Description:        "Production AWS",
+		AWSAccessKeyID:     "AKIAIOSFODNN7EXAMPLE",
+		AWSSecretAccessKey: "wJalrXUtnFEMI/K7MDENG",
+		AWSDefaultRegion:   "us-east-1",
+	}
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, CloudCredentialsPath, bytes.NewReader(b))
+	req = req.WithContext(createAdminContext())
+	w := httptest.NewRecorder()
+
+	handler.CreateCloudCredential(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp cloudcreds.CreateCloudCredentialResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if resp.Name != "aws-prod" {
+		t.Errorf("expected name 'aws-prod', got %q", resp.Name)
+	}
+}
+
+func TestCreateCloudCredential_GCP_Success(t *testing.T) {
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(newCloudCredScheme()).Build()
+	handler := NewTestHandler(fakeClient, fake.NewSimpleClientset(), "default", "localhost:50051")
+
+	gcpJSON := base64.StdEncoding.EncodeToString([]byte(`{"type":"service_account","project_id":"my-project"}`))
+	body := cloudcreds.CreateCloudCredentialRequest{
+		Name:                  "gcp-prod",
+		Provider:              cloudcreds.ProviderGCP,
+		GCPServiceAccountJSON: gcpJSON,
+	}
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, CloudCredentialsPath, bytes.NewReader(b))
+	req = req.WithContext(createAdminContext())
+	w := httptest.NewRecorder()
+
+	handler.CreateCloudCredential(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateCloudCredential_Forbidden(t *testing.T) {
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(newCloudCredScheme()).Build()
+	handler := NewTestHandler(fakeClient, fake.NewSimpleClientset(), "default", "localhost:50051")
+
+	body := cloudcreds.CreateCloudCredentialRequest{
+		Name: "aws-prod", Provider: cloudcreds.ProviderAWS,
+		AWSAccessKeyID: "k", AWSSecretAccessKey: "s", AWSDefaultRegion: "r",
+	}
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, CloudCredentialsPath, bytes.NewReader(b))
+	req = req.WithContext(createUserContext("user@example.com"))
+	w := httptest.NewRecorder()
+
+	handler.CreateCloudCredential(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestCreateCloudCredential_MissingName(t *testing.T) {
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(newCloudCredScheme()).Build()
+	handler := NewTestHandler(fakeClient, fake.NewSimpleClientset(), "default", "localhost:50051")
+
+	body := cloudcreds.CreateCloudCredentialRequest{Provider: cloudcreds.ProviderAWS}
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, CloudCredentialsPath, bytes.NewReader(b))
+	req = req.WithContext(createAdminContext())
+	w := httptest.NewRecorder()
+
+	handler.CreateCloudCredential(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestCreateCloudCredential_InvalidProvider(t *testing.T) {
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(newCloudCredScheme()).Build()
+	handler := NewTestHandler(fakeClient, fake.NewSimpleClientset(), "default", "localhost:50051")
+
+	body := cloudcreds.CreateCloudCredentialRequest{Name: "test", Provider: "oracle"}
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, CloudCredentialsPath, bytes.NewReader(b))
+	req = req.WithContext(createAdminContext())
+	w := httptest.NewRecorder()
+
+	handler.CreateCloudCredential(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestCreateCloudCredential_ReservedName(t *testing.T) {
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(newCloudCredScheme()).Build()
+	handler := NewTestHandler(fakeClient, fake.NewSimpleClientset(), "default", "localhost:50051")
+
+	body := cloudcreds.CreateCloudCredentialRequest{
+		Name: "available", Provider: cloudcreds.ProviderAWS,
+		AWSAccessKeyID: "k", AWSSecretAccessKey: "s", AWSDefaultRegion: "r",
+	}
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, CloudCredentialsPath, bytes.NewReader(b))
+	req = req.WithContext(createAdminContext())
+	w := httptest.NewRecorder()
+
+	handler.CreateCloudCredential(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestCreateCloudCredential_DuplicateName(t *testing.T) {
+	existing := newAWSTestSecret("aws-prod", "default")
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(newCloudCredScheme()).WithObjects(existing).Build()
+	handler := NewTestHandler(fakeClient, fake.NewSimpleClientset(), "default", "localhost:50051")
+
+	body := cloudcreds.CreateCloudCredentialRequest{
+		Name: "aws-prod", Provider: cloudcreds.ProviderAWS,
+		AWSAccessKeyID: "k", AWSSecretAccessKey: "s", AWSDefaultRegion: "r",
+	}
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, CloudCredentialsPath, bytes.NewReader(b))
+	req = req.WithContext(createAdminContext())
+	w := httptest.NewRecorder()
+
+	handler.CreateCloudCredential(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateCloudCredential_InvalidBody(t *testing.T) {
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(newCloudCredScheme()).Build()
+	handler := NewTestHandler(fakeClient, fake.NewSimpleClientset(), "default", "localhost:50051")
+
+	req := httptest.NewRequest(http.MethodPost, CloudCredentialsPath, bytes.NewReader([]byte("not-json")))
+	req = req.WithContext(createAdminContext())
+	w := httptest.NewRecorder()
+
+	handler.CreateCloudCredential(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+// ── ListCloudCredentials ────────────────────────────────────────────────────
+
+func TestListCloudCredentials_Success(t *testing.T) {
+	s1 := newAWSTestSecret("aws-prod", "default")
+	s2 := newGCPTestSecret("gcp-prod", "default")
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(newCloudCredScheme()).WithObjects(s1, s2).Build()
+	handler := NewTestHandler(fakeClient, fake.NewSimpleClientset(), "default", "localhost:50051")
+
+	req := httptest.NewRequest(http.MethodGet, CloudCredentialsPath, nil)
+	req = req.WithContext(createAdminContext())
+	w := httptest.NewRecorder()
+
+	handler.ListCloudCredentials(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp cloudcreds.ListCloudCredentialsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if resp.Total != 2 {
+		t.Errorf("expected Total=2, got %d", resp.Total)
+	}
+}
+
+func TestListCloudCredentials_Empty(t *testing.T) {
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(newCloudCredScheme()).Build()
+	handler := NewTestHandler(fakeClient, fake.NewSimpleClientset(), "default", "localhost:50051")
+
+	req := httptest.NewRequest(http.MethodGet, CloudCredentialsPath, nil)
+	req = req.WithContext(createAdminContext())
+	w := httptest.NewRecorder()
+
+	handler.ListCloudCredentials(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+
+	var resp cloudcreds.ListCloudCredentialsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if resp.Total != 0 {
+		t.Errorf("expected Total=0, got %d", resp.Total)
+	}
+}
+
+func TestListCloudCredentials_NonAdminForbidden(t *testing.T) {
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(newCloudCredScheme()).Build()
+	handler := NewTestHandler(fakeClient, fake.NewSimpleClientset(), "default", "localhost:50051")
+
+	req := httptest.NewRequest(http.MethodGet, CloudCredentialsPath, nil)
+	req = req.WithContext(createUserContext("user@example.com"))
+	w := httptest.NewRecorder()
+
+	handler.ListCloudCredentials(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestListCloudCredentials_ExcludesNonCloudCredSecrets(t *testing.T) {
+	cloudSecret := newAWSTestSecret("aws-prod", "default")
+	otherSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "some-other-secret",
+			Namespace: "default",
+			Labels:    map[string]string{"app.kubernetes.io/component": "not-cloud-credential"},
+		},
+		Data: map[string][]byte{"key": []byte("value")},
+	}
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(newCloudCredScheme()).WithObjects(cloudSecret, otherSecret).Build()
+	handler := NewTestHandler(fakeClient, fake.NewSimpleClientset(), "default", "localhost:50051")
+
+	req := httptest.NewRequest(http.MethodGet, CloudCredentialsPath, nil)
+	req = req.WithContext(createAdminContext())
+	w := httptest.NewRecorder()
+
+	handler.ListCloudCredentials(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	var resp cloudcreds.ListCloudCredentialsResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Total != 1 {
+		t.Errorf("expected Total=1 (only cloud cred), got %d", resp.Total)
+	}
+}
+
+// ── GetCloudCredential ──────────────────────────────────────────────────────
+
+func TestGetCloudCredential_Success(t *testing.T) {
+	existing := newAWSTestSecret("aws-prod", "default")
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(newCloudCredScheme()).WithObjects(existing).Build()
+	handler := NewTestHandler(fakeClient, fake.NewSimpleClientset(), "default", "localhost:50051")
+
+	req := httptest.NewRequest(http.MethodGet, CloudCredentialsPath+"/aws-prod", nil)
+	req = req.WithContext(createAdminContext())
+	w := httptest.NewRecorder()
+
+	handler.GetCloudCredential(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp cloudcreds.CloudCredentialResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if resp.Name != "aws-prod" {
+		t.Errorf("expected name 'aws-prod', got %q", resp.Name)
+	}
+	if resp.Provider != cloudcreds.ProviderAWS {
+		t.Errorf("expected provider 'aws', got %q", resp.Provider)
+	}
+}
+
+func TestGetCloudCredential_NotFound(t *testing.T) {
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(newCloudCredScheme()).Build()
+	handler := NewTestHandler(fakeClient, fake.NewSimpleClientset(), "default", "localhost:50051")
+
+	req := httptest.NewRequest(http.MethodGet, CloudCredentialsPath+"/nonexistent", nil)
+	req = req.WithContext(createAdminContext())
+	w := httptest.NewRecorder()
+
+	handler.GetCloudCredential(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestGetCloudCredential_ResponseExcludesSecretData(t *testing.T) {
+	existing := newAWSTestSecret("aws-prod", "default")
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(newCloudCredScheme()).WithObjects(existing).Build()
+	handler := NewTestHandler(fakeClient, fake.NewSimpleClientset(), "default", "localhost:50051")
+
+	req := httptest.NewRequest(http.MethodGet, CloudCredentialsPath+"/aws-prod", nil)
+	req = req.WithContext(createAdminContext())
+	w := httptest.NewRecorder()
+
+	handler.GetCloudCredential(w, req)
+
+	body := w.Body.String()
+	if bytes.Contains([]byte(body), []byte("AKIATEST")) {
+		t.Error("response should not contain Secret data (access key)")
+	}
+	if bytes.Contains([]byte(body), []byte("secret")) && bytes.Contains([]byte(body), []byte("AccessKey")) {
+		t.Error("response should not contain Secret data")
+	}
+}
+
+// ── UpdateCloudCredential ───────────────────────────────────────────────────
+
+func TestUpdateCloudCredential_Success(t *testing.T) {
+	existing := newAWSTestSecret("aws-prod", "default")
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(newCloudCredScheme()).WithObjects(existing).Build()
+	handler := NewTestHandler(fakeClient, fake.NewSimpleClientset(), "default", "localhost:50051")
+
+	body := cloudcreds.UpdateCloudCredentialRequest{
+		Description:    "Updated description",
+		AWSDefaultRegion: "eu-west-1",
+	}
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPut, CloudCredentialsPath+"/aws-prod", bytes.NewReader(b))
+	req = req.WithContext(createAdminContext())
+	w := httptest.NewRecorder()
+
+	handler.UpdateCloudCredential(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateCloudCredential_NotFound(t *testing.T) {
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(newCloudCredScheme()).Build()
+	handler := NewTestHandler(fakeClient, fake.NewSimpleClientset(), "default", "localhost:50051")
+
+	body := cloudcreds.UpdateCloudCredentialRequest{AWSDefaultRegion: "eu-west-1"}
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPut, CloudCredentialsPath+"/nonexistent", bytes.NewReader(b))
+	req = req.WithContext(createAdminContext())
+	w := httptest.NewRecorder()
+
+	handler.UpdateCloudCredential(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+// ── DeleteCloudCredential ───────────────────────────────────────────────────
+
+func TestDeleteCloudCredential_Success(t *testing.T) {
+	existing := newAWSTestSecret("aws-prod", "default")
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(newCloudCredScheme()).WithObjects(existing).Build()
+	handler := NewTestHandler(fakeClient, fake.NewSimpleClientset(), "default", "localhost:50051")
+
+	req := httptest.NewRequest(http.MethodDelete, CloudCredentialsPath+"/aws-prod", nil)
+	req = req.WithContext(createAdminContext())
+	w := httptest.NewRecorder()
+
+	handler.DeleteCloudCredential(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDeleteCloudCredential_NotFound(t *testing.T) {
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(newCloudCredScheme()).Build()
+	handler := NewTestHandler(fakeClient, fake.NewSimpleClientset(), "default", "localhost:50051")
+
+	req := httptest.NewRequest(http.MethodDelete, CloudCredentialsPath+"/nonexistent", nil)
+	req = req.WithContext(createAdminContext())
+	w := httptest.NewRecorder()
+
+	handler.DeleteCloudCredential(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+// ── ListAvailableCloudCredentials ───────────────────────────────────────────
+
+func TestListAvailableCloudCredentials_AdminSeesAll(t *testing.T) {
+	s1 := newAWSTestSecret("aws-prod", "default")
+	s2 := newGroupedAWSSecret("aws-team", "default", []string{"team-a"})
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(newCloudCredScheme()).WithObjects(s1, s2).Build()
+	handler := NewTestHandler(fakeClient, fake.NewSimpleClientset(), "default", "localhost:50051")
+
+	req := httptest.NewRequest(http.MethodGet, CloudCredentialsAvailablePath, nil)
+	req = req.WithContext(createAdminContext())
+	w := httptest.NewRecorder()
+
+	handler.ListAvailableCloudCredentials(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp cloudcreds.ListCloudCredentialsResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Total != 2 {
+		t.Errorf("expected admin to see 2 credentials, got %d", resp.Total)
+	}
+}
+
+func TestListAvailableCloudCredentials_AvailableToAll(t *testing.T) {
+	s := newGCPTestSecret("gcp-public", "default") // availableToAll=true
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(newCloudCredScheme()).WithObjects(s).Build()
+	handler := NewTestHandler(fakeClient, fake.NewSimpleClientset(), "default", "localhost:50051")
+
+	req := httptest.NewRequest(http.MethodGet, CloudCredentialsAvailablePath, nil)
+	req = req.WithContext(createUserContext("user@example.com"))
+	w := httptest.NewRecorder()
+
+	handler.ListAvailableCloudCredentials(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+
+	var resp cloudcreds.ListCloudCredentialsResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Total != 1 {
+		t.Errorf("expected user to see 1 available-to-all credential, got %d", resp.Total)
+	}
+}
+
+func TestListAvailableCloudCredentials_NonMemberSeesNothing(t *testing.T) {
+	s := newGroupedAWSSecret("aws-team", "default", []string{"team-a"})
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(newCloudCredScheme()).WithObjects(s).Build()
+	handler := NewTestHandler(fakeClient, fake.NewSimpleClientset(), "default", "localhost:50051")
+
+	req := httptest.NewRequest(http.MethodGet, CloudCredentialsAvailablePath, nil)
+	req = req.WithContext(createUserContext("outsider@example.com"))
+	w := httptest.NewRecorder()
+
+	handler.ListAvailableCloudCredentials(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+
+	var resp cloudcreds.ListCloudCredentialsResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Total != 0 {
+		t.Errorf("expected non-member to see 0 credentials, got %d", resp.Total)
+	}
+}
+
+// ── Router ──────────────────────────────────────────────────────────────────
+
+func TestCloudCredentialsRouter_MethodNotAllowed(t *testing.T) {
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(newCloudCredScheme()).Build()
+	handler := NewTestHandler(fakeClient, fake.NewSimpleClientset(), "default", "localhost:50051")
+
+	req := httptest.NewRequest(http.MethodPatch, CloudCredentialsPath, nil)
+	req = req.WithContext(createAdminContext())
+	w := httptest.NewRecorder()
+
+	handler.CloudCredentialsRouter(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestCloudCredentialsRouter_SubpathMethodNotAllowed(t *testing.T) {
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(newCloudCredScheme()).Build()
+	handler := NewTestHandler(fakeClient, fake.NewSimpleClientset(), "default", "localhost:50051")
+
+	req := httptest.NewRequest(http.MethodPatch, CloudCredentialsPath+"/aws-prod", nil)
+	req = req.WithContext(createAdminContext())
+	w := httptest.NewRecorder()
+
+	handler.CloudCredentialsRouter(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+// ── GCP base64 decode verification ──────────────────────────────────────────
+
+func TestCreateCloudCredential_GCP_DecodesBase64(t *testing.T) {
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(newCloudCredScheme()).Build()
+	handler := NewTestHandler(fakeClient, fake.NewSimpleClientset(), "default", "localhost:50051")
+
+	originalJSON := `{"type":"service_account","project_id":"my-project"}`
+	gcpJSON := base64.StdEncoding.EncodeToString([]byte(originalJSON))
+	body := cloudcreds.CreateCloudCredentialRequest{
+		Name:                  "gcp-test",
+		Provider:              cloudcreds.ProviderGCP,
+		GCPServiceAccountJSON: gcpJSON,
+	}
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, CloudCredentialsPath, bytes.NewReader(b))
+	req = req.WithContext(createAdminContext())
+	w := httptest.NewRecorder()
+
+	handler.CreateCloudCredential(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Verify the stored Secret has decoded JSON, not base64
+	var stored corev1.Secret
+	if err := fakeClient.Get(req.Context(), k8stypes.NamespacedName{
+		Name: "gcp-test", Namespace: "default",
+	}, &stored); err != nil {
+		t.Fatalf("failed to get stored secret: %v", err)
+	}
+
+	storedData := string(stored.Data[cloudcreds.SecretKeyGCPServiceAccountJSON])
+	if storedData != originalJSON {
+		t.Errorf("expected decoded JSON %q, got %q", originalJSON, storedData)
+	}
+}

--- a/internal/api/graphrun_handlers.go
+++ b/internal/api/graphrun_handlers.go
@@ -452,6 +452,7 @@ func (h *Handler) CreateGraphRun(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Validate cloud credential access if specified (graph-level and per-node)
+	req.CloudCredentialRef = strings.TrimSpace(req.CloudCredentialRef)
 	if req.CloudCredentialRef != "" {
 		credSecret, err := h.loadCloudCredentialSecret(ctx, req.CloudCredentialRef)
 		if err != nil {

--- a/internal/api/graphrun_handlers.go
+++ b/internal/api/graphrun_handlers.go
@@ -451,6 +451,46 @@ func (h *Handler) CreateGraphRun(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Validate cloud credential access if specified (graph-level and per-node)
+	if req.CloudCredentialRef != "" {
+		credSecret, err := h.loadCloudCredentialSecret(ctx, req.CloudCredentialRef)
+		if err != nil {
+			logger.Error(err, "Failed to load cloud credential for graph run", "name", req.CloudCredentialRef)
+			writeJSONError(w, http.StatusBadRequest, ErrorResponse{
+				Error:   "bad_request",
+				Message: fmt.Sprintf("Cloud credential '%s' not found or inaccessible", req.CloudCredentialRef),
+			})
+			return
+		}
+		if !h.canAccessCloudCredential(ctx, credSecret) {
+			writeJSONError(w, http.StatusForbidden, ErrorResponse{
+				Error:   "forbidden",
+				Message: fmt.Sprintf("Access denied to cloud credential '%s'", req.CloudCredentialRef),
+			})
+			return
+		}
+	}
+	for nodeID, node := range req.Graph {
+		if node.CloudCredentialRef != "" && node.CloudCredentialRef != req.CloudCredentialRef {
+			credSecret, err := h.loadCloudCredentialSecret(ctx, node.CloudCredentialRef)
+			if err != nil {
+				logger.Error(err, "Failed to load cloud credential for graph node", "nodeID", nodeID, "name", node.CloudCredentialRef)
+				writeJSONError(w, http.StatusBadRequest, ErrorResponse{
+					Error:   "bad_request",
+					Message: fmt.Sprintf("Cloud credential '%s' for node '%s' not found or inaccessible", node.CloudCredentialRef, nodeID),
+				})
+				return
+			}
+			if !h.canAccessCloudCredential(ctx, credSecret) {
+				writeJSONError(w, http.StatusForbidden, ErrorResponse{
+					Error:   "forbidden",
+					Message: fmt.Sprintf("Access denied to cloud credential '%s' for node '%s'", node.CloudCredentialRef, nodeID),
+				})
+				return
+			}
+		}
+	}
+
 	// Generate unique name for the graph run
 	graphRunName := fmt.Sprintf("graphrun-%s", uuid.New().String()[:8])
 
@@ -465,6 +505,7 @@ func (h *Handler) CreateGraphRun(w http.ResponseWriter, r *http.Request) {
 			TargetRequestID:         req.TargetRequestID,
 			TargetClusters:          req.TargetClusters,
 			OwnerUserID:             userClaims.UserID,
+			CloudCredentialRef:      req.CloudCredentialRef,
 			ResiliencyScoreEnabled:  resiliencyEnabled,
 			ResiliencyMountPath:     resiliencyMountPath,
 			ResiliencyScoreBaseline: resiliencyBaseline,

--- a/internal/api/graphrun_handlers.go
+++ b/internal/api/graphrun_handlers.go
@@ -462,7 +462,16 @@ func (h *Handler) CreateGraphRun(w http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
-		if !h.canAccessCloudCredential(ctx, credSecret) {
+		allowed, accessErr := h.canAccessCloudCredential(ctx, credSecret)
+		if accessErr != nil {
+			logger.Error(accessErr, "Failed to check cloud credential access", "name", req.CloudCredentialRef)
+			writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
+				Error:   "internal_error",
+				Message: "Failed to verify cloud credential access",
+			})
+			return
+		}
+		if !allowed {
 			writeJSONError(w, http.StatusForbidden, ErrorResponse{
 				Error:   "forbidden",
 				Message: fmt.Sprintf("Access denied to cloud credential '%s'", req.CloudCredentialRef),
@@ -481,7 +490,16 @@ func (h *Handler) CreateGraphRun(w http.ResponseWriter, r *http.Request) {
 				})
 				return
 			}
-			if !h.canAccessCloudCredential(ctx, credSecret) {
+			allowed, accessErr := h.canAccessCloudCredential(ctx, credSecret)
+			if accessErr != nil {
+				logger.Error(accessErr, "Failed to check cloud credential access", "nodeID", nodeID, "name", node.CloudCredentialRef)
+				writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
+					Error:   "internal_error",
+					Message: "Failed to verify cloud credential access",
+				})
+				return
+			}
+			if !allowed {
 				writeJSONError(w, http.StatusForbidden, ErrorResponse{
 					Error:   "forbidden",
 					Message: fmt.Sprintf("Access denied to cloud credential '%s' for node '%s'", node.CloudCredentialRef, nodeID),

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1392,7 +1392,16 @@ func (h *Handler) PostScenarioRun(w http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
-		if !h.canAccessCloudCredential(ctx, credSecret) {
+		allowed, accessErr := h.canAccessCloudCredential(ctx, credSecret)
+		if accessErr != nil {
+			logger.Error(accessErr, "Failed to check cloud credential access", "name", req.CloudCredentialRef)
+			writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
+				Error:   "internal_error",
+				Message: "Failed to verify cloud credential access",
+			})
+			return
+		}
+		if !allowed {
 			writeJSONError(w, http.StatusForbidden, ErrorResponse{
 				Error:   "forbidden",
 				Message: fmt.Sprintf("Access denied to cloud credential '%s'", req.CloudCredentialRef),

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1382,6 +1382,7 @@ func (h *Handler) PostScenarioRun(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Validate cloud credential access if specified
+	req.CloudCredentialRef = strings.TrimSpace(req.CloudCredentialRef)
 	if req.CloudCredentialRef != "" {
 		credSecret, err := h.loadCloudCredentialSecret(ctx, req.CloudCredentialRef)
 		if err != nil {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -31,13 +31,13 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"golang.org/x/sync/errgroup"
 	"github.com/gorilla/websocket"
 	"github.com/krkn-chaos/krknctl/pkg/config"
 	"github.com/krkn-chaos/krknctl/pkg/provider"
 	"github.com/krkn-chaos/krknctl/pkg/provider/factory"
 	"github.com/krkn-chaos/krknctl/pkg/provider/models"
 	"github.com/krkn-chaos/krknctl/pkg/typing"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	corev1 "k8s.io/api/core/v1"
@@ -1381,6 +1381,26 @@ func (h *Handler) PostScenarioRun(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Validate cloud credential access if specified
+	if req.CloudCredentialRef != "" {
+		credSecret, err := h.loadCloudCredentialSecret(ctx, req.CloudCredentialRef)
+		if err != nil {
+			logger.Error(err, "Failed to load cloud credential for run", "name", req.CloudCredentialRef)
+			writeJSONError(w, http.StatusBadRequest, ErrorResponse{
+				Error:   "bad_request",
+				Message: fmt.Sprintf("Cloud credential '%s' not found or inaccessible", req.CloudCredentialRef),
+			})
+			return
+		}
+		if !h.canAccessCloudCredential(ctx, credSecret) {
+			writeJSONError(w, http.StatusForbidden, ErrorResponse{
+				Error:   "forbidden",
+				Message: fmt.Sprintf("Access denied to cloud credential '%s'", req.CloudCredentialRef),
+			})
+			return
+		}
+	}
+
 	// Create KrknScenarioRun CR
 	// Extract user claims for ownership tracking (defensive check for tests)
 	claims := auth.GetClaimsFromContext(ctx)
@@ -1427,6 +1447,11 @@ func (h *Handler) PostScenarioRun(w http.ResponseWriter, r *http.Request) {
 		if registryConfig.Password != nil {
 			scenarioRun.Spec.Password = *registryConfig.Password
 		}
+	}
+
+	// Set cloud credential reference on CRD spec (controller handles SecretKeyRef injection)
+	if req.CloudCredentialRef != "" {
+		scenarioRun.Spec.CloudCredentialRef = req.CloudCredentialRef
 	}
 
 	// Convert FileMount from API type to CRD type (merged from inline Files and translated FileReferences)

--- a/internal/api/pagination_test.go
+++ b/internal/api/pagination_test.go
@@ -24,14 +24,14 @@ import (
 
 func TestPaginateSlice(t *testing.T) {
 	tests := []struct {
-		name          string
-		items         []int
-		page          int
-		limit         int
-		wantLen       int
-		wantFirst     int // -1 to skip
-		wantTotal     int
-		wantTotalPgs  int
+		name         string
+		items        []int
+		page         int
+		limit        int
+		wantLen      int
+		wantFirst    int // -1 to skip
+		wantTotal    int
+		wantTotalPgs int
 	}{
 		{"FirstPage", []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 1, 3, 3, 1, 10, 4},
 		{"MiddlePage", []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 2, 3, 3, 4, 10, 4},

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -113,3 +113,9 @@ const (
 const (
 	ElasticsearchConfigsPath = APIBasePath + "/elasticsearch-configs"
 )
+
+// Cloud credential endpoints
+const (
+	CloudCredentialsPath          = APIBasePath + "/cloud-credentials"
+	CloudCredentialsAvailablePath = CloudCredentialsPath + "/available"
+)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -216,6 +216,7 @@ func NewServer(port int, client client.Client, clientset kubernetes.Interface, n
 	mux.Handle(ElasticsearchConfigsPath+"/", authMw.RequireAuth(http.HandlerFunc(handler.ElasticsearchConfigsRouter)))
 	// Cloud credential endpoints
 	mux.Handle(CloudCredentialsAvailablePath, authMw.RequireAuth(http.HandlerFunc(handler.ListAvailableCloudCredentials)))
+	mux.Handle(CloudCredentialsAvailablePath+"/", authMw.RequireAuth(http.HandlerFunc(handler.ListAvailableCloudCredentials)))
 	mux.Handle(CloudCredentialsPath, authMw.RequireAuth(http.HandlerFunc(handler.CloudCredentialsRouter)))
 	mux.Handle(CloudCredentialsPath+"/", authMw.RequireAuth(http.HandlerFunc(handler.CloudCredentialsRouter)))
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -214,6 +214,10 @@ func NewServer(port int, client client.Client, clientset kubernetes.Interface, n
 	// Elasticsearch config endpoints - admin only
 	mux.Handle(ElasticsearchConfigsPath, authMw.RequireAuth(http.HandlerFunc(handler.ElasticsearchConfigsRouter)))
 	mux.Handle(ElasticsearchConfigsPath+"/", authMw.RequireAuth(http.HandlerFunc(handler.ElasticsearchConfigsRouter)))
+	// Cloud credential endpoints
+	mux.Handle(CloudCredentialsAvailablePath, authMw.RequireAuth(http.HandlerFunc(handler.ListAvailableCloudCredentials)))
+	mux.Handle(CloudCredentialsPath, authMw.RequireAuth(http.HandlerFunc(handler.CloudCredentialsRouter)))
+	mux.Handle(CloudCredentialsPath+"/", authMw.RequireAuth(http.HandlerFunc(handler.CloudCredentialsRouter)))
 
 	// ==================== API v2 Endpoints ====================
 	// v2 REST endpoints reuse v1 handlers (backward compatible)

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -164,6 +164,9 @@ type ScenarioRunRequest struct {
 	// credentials (ES_PASSWORD, and any ES_* vars not already in Environment) are
 	// injected server-side so the password is never transmitted by the client.
 	ElasticsearchConfigName string `json:"elasticsearchConfigName,omitempty"`
+	// CloudCredentialRef, if set, names a saved cloud credential Secret whose
+	// reference is set on the CRD spec for controller-level SecretKeyRef injection.
+	CloudCredentialRef string `json:"cloudCredentialRef,omitempty"`
 	// Private registry configuration (optional)
 	ScenariosRequest
 }
@@ -776,6 +779,8 @@ type GraphRunCreateRequest struct {
 	TargetRequestID string `json:"targetRequestId"`
 	// TargetClusters is a map of provider-name to list of cluster names
 	TargetClusters map[string][]string `json:"targetClusters"`
+	// CloudCredentialRef is the default cloud credential for all nodes (optional)
+	CloudCredentialRef string `json:"cloudCredentialRef,omitempty"`
 }
 
 // GraphRunListItem represents a single item in the graph runs list

--- a/internal/api/user_handlers.go
+++ b/internal/api/user_handlers.go
@@ -113,7 +113,6 @@ func filterUsers(users []krknv1alpha1.KrknUser, role, activeParam, search string
 	return filtered
 }
 
-
 // sanitizeUsername converts an email to a valid Kubernetes resource name of the
 // form "krknuser-<sanitized>".
 //

--- a/internal/api/v2/websocket/response_helpers.go
+++ b/internal/api/v2/websocket/response_helpers.go
@@ -12,9 +12,9 @@ import (
 // WSUnifiedJobItem represents a single item in the unified jobs list for WebSocket responses.
 // Uses the same typed envelope as REST UnifiedJobItem for frontend compatibility.
 type WSUnifiedJobItem struct {
-	Type        string                    `json:"type"`                  // "scenarioRun" or "graphRun"
-	Name        string                    `json:"name"`
-	CreatedAt   string                    `json:"createdAt"`             // RFC3339 timestamp
+	Type        string                     `json:"type"` // "scenarioRun" or "graphRun"
+	Name        string                     `json:"name"`
+	CreatedAt   string                     `json:"createdAt"` // RFC3339 timestamp
 	ScenarioRun *ScenarioRunStatusResponse `json:"scenarioRun,omitempty"`
 	GraphRun    *GraphRunResponse          `json:"graphRun,omitempty"`
 }

--- a/internal/api/v2/websocket/types.go
+++ b/internal/api/v2/websocket/types.go
@@ -110,18 +110,18 @@ type WSPaginationMeta struct {
 
 // ServerMessage is sent from server to client
 type ServerMessage struct {
-	Resource   string            `json:"resource"`              // "run", "graphrun", "dashboard", "jobs"
-	ID         string            `json:"id,omitempty"`          // resource ID (empty for dashboard/jobs)
-	Event      string            `json:"event"`                 // "updated", "deleted", "snapshot"
-	Data       interface{}       `json:"data"`                  // payload
-	Pagination *WSPaginationMeta `json:"pagination,omitempty"`  // pagination metadata (for "jobs" resource)
+	Resource   string            `json:"resource"`             // "run", "graphrun", "dashboard", "jobs"
+	ID         string            `json:"id,omitempty"`         // resource ID (empty for dashboard/jobs)
+	Event      string            `json:"event"`                // "updated", "deleted", "snapshot"
+	Data       interface{}       `json:"data"`                 // payload
+	Pagination *WSPaginationMeta `json:"pagination,omitempty"` // pagination metadata (for "jobs" resource)
 }
 
 // ClientMessage is sent from client to server
 type ClientMessage struct {
-	Action   string   `json:"action"`        // "subscribe", "unsubscribe"
-	Resource string   `json:"resource"`      // "run", "graphrun", "dashboard", "jobs"
-	IDs      []string `json:"ids,omitempty"` // specific resource IDs (empty = wildcard)
+	Action   string   `json:"action"`          // "subscribe", "unsubscribe"
+	Resource string   `json:"resource"`        // "run", "graphrun", "dashboard", "jobs"
+	IDs      []string `json:"ids,omitempty"`   // specific resource IDs (empty = wildcard)
 	Page     *int     `json:"page,omitempty"`  // page number for paginated subscriptions (1-based)
 	Limit    *int     `json:"limit,omitempty"` // items per page for paginated subscriptions
 }

--- a/internal/api/v2/websocket/watcher.go
+++ b/internal/api/v2/websocket/watcher.go
@@ -91,9 +91,9 @@ func (h *scenarioRunEventHandler) OnAdd(obj interface{}, _ bool) {
 
 	h.logger.V(1).Info("ScenarioRun added", "name", run.Name)
 	// Broadcaster will deduplicate via cache, so always call it
-	h.broadcaster.BroadcastScenarioRunUpdate(run)       // Lightweight (no clusterJobs)
-	h.broadcaster.BroadcastScenarioRunDetailUpdate(run) // Full detail (with clusterJobs)
-	h.broadcaster.BroadcastJobsPageUpdate(context.Background())             // Unified paginated view
+	h.broadcaster.BroadcastScenarioRunUpdate(run)               // Lightweight (no clusterJobs)
+	h.broadcaster.BroadcastScenarioRunDetailUpdate(run)         // Full detail (with clusterJobs)
+	h.broadcaster.BroadcastJobsPageUpdate(context.Background()) // Unified paginated view
 }
 
 func (h *scenarioRunEventHandler) OnUpdate(oldObj, newObj interface{}) {
@@ -122,9 +122,9 @@ func (h *scenarioRunEventHandler) OnUpdate(oldObj, newObj interface{}) {
 		"newPhase", newRun.Status.Phase,
 		"runningJobs", newRun.Status.RunningJobs)
 
-	h.broadcaster.BroadcastScenarioRunUpdate(newRun)       // Lightweight (no clusterJobs)
-	h.broadcaster.BroadcastScenarioRunDetailUpdate(newRun) // Full detail (with clusterJobs)
-	h.broadcaster.BroadcastJobsPageUpdate(context.Background())                // Unified paginated view
+	h.broadcaster.BroadcastScenarioRunUpdate(newRun)            // Lightweight (no clusterJobs)
+	h.broadcaster.BroadcastScenarioRunDetailUpdate(newRun)      // Full detail (with clusterJobs)
+	h.broadcaster.BroadcastJobsPageUpdate(context.Background()) // Unified paginated view
 
 	// Update dashboard with current active runs count
 	h.broadcastDashboardUpdate(context.Background())

--- a/internal/controller/krkngraphrun_controller.go
+++ b/internal/controller/krkngraphrun_controller.go
@@ -525,6 +525,11 @@ func (r *KrknGraphRunReconciler) createScenarioRun(
 			"fileCount", len(fileMounts))
 	}
 
+	// Propagate cloud credential ref: per-node override takes precedence over graph-level
+	if ref := overrideRef(node.CloudCredentialRef, graphRun.Spec.CloudCredentialRef); ref != "" {
+		spec.CloudCredentialRef = ref
+	}
+
 	// Handle resiliency score environment variables (controller-reserved)
 	// These env vars are exclusively managed by the controller and should never
 	// come from user-defined node.Env. Strip them first to prevent leakage.

--- a/internal/controller/krknscenariorun_controller.go
+++ b/internal/controller/krknscenariorun_controller.go
@@ -45,6 +45,7 @@ import (
 	krknv1alpha1 "github.com/krkn-chaos/krkn-operator/api/v1alpha1"
 
 	"github.com/google/uuid"
+	"github.com/krkn-chaos/krkn-operator/pkg/cloudcreds"
 	krknctlconfig "github.com/krkn-chaos/krknctl/pkg/config"
 )
 
@@ -711,6 +712,27 @@ func (r *KrknScenarioRunReconciler) prepareJobResources(
 			Name:  key,
 			Value: value,
 		})
+	}
+
+	// Inject cloud credentials via SecretKeyRef if specified
+	if scenarioRun.Spec.CloudCredentialRef != "" {
+		var credSecret corev1.Secret
+		if err := r.Get(ctx, types.NamespacedName{
+			Name:      scenarioRun.Spec.CloudCredentialRef,
+			Namespace: r.Namespace,
+		}, &credSecret); err != nil {
+			return nil, fmt.Errorf("failed to load cloud credential '%s': %w",
+				scenarioRun.Spec.CloudCredentialRef, err)
+		}
+
+		credEnvVars, credVolumes, credMounts, err := cloudcreds.InjectCredentials(&credSecret)
+		if err != nil {
+			return nil, fmt.Errorf("failed to inject cloud credentials: %w", err)
+		}
+
+		envVars = append(envVars, credEnvVars...)
+		volumes = append(volumes, credVolumes...)
+		volumeMounts = append(volumeMounts, credMounts...)
 	}
 
 	return &preparedJobResources{

--- a/internal/controller/provider_helpers.go
+++ b/internal/controller/provider_helpers.go
@@ -62,6 +62,15 @@ func checkProviderActive(ctx context.Context, c client.Client, operatorName stri
 	return true, providerList, nil
 }
 
+// overrideRef returns the node-level ref if set, otherwise the parent-level ref.
+// Used for graph-level ref propagation (cloud credentials, future registry refs, etc.).
+func overrideRef(nodeRef, parentRef string) string {
+	if nodeRef != "" {
+		return nodeRef
+	}
+	return parentRef
+}
+
 // countActiveProviders counts the number of active providers in the given list.
 // Returns the count and a slice of active provider names.
 func countActiveProviders(providerList *krknv1alpha1.KrknOperatorTargetProviderList) (int, []string) {

--- a/pkg/cloudcreds/injection.go
+++ b/pkg/cloudcreds/injection.go
@@ -46,6 +46,8 @@ func InjectCredentials(secret *corev1.Secret) ([]corev1.EnvVar, []corev1.Volume,
 		return injectAzure(secret.Name), nil, nil, nil
 	case ProviderOpenStack:
 		return injectOpenStack(secret.Name), nil, nil, nil
+	case ProviderBaremetal:
+		return injectBaremetal(secret.Name), nil, nil, nil
 	default:
 		return nil, nil, nil, fmt.Errorf("unsupported cloud provider: %s", provider)
 	}
@@ -114,5 +116,14 @@ func injectOpenStack(secretName string) []corev1.EnvVar {
 		{Name: "OS_PASSWORD", ValueFrom: secretKeyRef(secretName, SecretKeyOSPassword)},
 		{Name: "OS_PROJECT_NAME", ValueFrom: secretKeyRef(secretName, SecretKeyOSProjectName)},
 		{Name: "OS_DOMAIN_NAME", ValueFrom: secretKeyRef(secretName, SecretKeyOSDomainName)},
+	}
+}
+
+func injectBaremetal(secretName string) []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{Name: "CLOUD_TYPE", Value: "bm"},
+		{Name: "BMC_USER", ValueFrom: secretKeyRef(secretName, SecretKeyBMCUser)},
+		{Name: "BMC_PASSWORD", ValueFrom: secretKeyRef(secretName, SecretKeyBMCPassword)},
+		{Name: "BMC_ADDR", ValueFrom: secretKeyRef(secretName, SecretKeyBMCAddr)},
 	}
 }

--- a/pkg/cloudcreds/injection.go
+++ b/pkg/cloudcreds/injection.go
@@ -48,6 +48,10 @@ func InjectCredentials(secret *corev1.Secret) ([]corev1.EnvVar, []corev1.Volume,
 		return injectOpenStack(secret.Name), nil, nil, nil
 	case ProviderBaremetal:
 		return injectBaremetal(secret.Name), nil, nil, nil
+	case ProviderVMware:
+		return injectVMware(secret.Name), nil, nil, nil
+	case ProviderIBMCloud:
+		return injectIBMCloud(secret.Name), nil, nil, nil
 	default:
 		return nil, nil, nil, fmt.Errorf("unsupported cloud provider: %s", provider)
 	}
@@ -125,5 +129,22 @@ func injectBaremetal(secretName string) []corev1.EnvVar {
 		{Name: "BMC_USER", ValueFrom: secretKeyRef(secretName, SecretKeyBMCUser)},
 		{Name: "BMC_PASSWORD", ValueFrom: secretKeyRef(secretName, SecretKeyBMCPassword)},
 		{Name: "BMC_ADDR", ValueFrom: secretKeyRef(secretName, SecretKeyBMCAddr)},
+	}
+}
+
+func injectVMware(secretName string) []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{Name: "CLOUD_TYPE", Value: "vmware"},
+		{Name: "VSPHERE_IP", ValueFrom: secretKeyRef(secretName, SecretKeyVSphereIP)},
+		{Name: "VSPHERE_USERNAME", ValueFrom: secretKeyRef(secretName, SecretKeyVSphereUsername)},
+		{Name: "VSPHERE_PASSWORD", ValueFrom: secretKeyRef(secretName, SecretKeyVSpherePassword)},
+	}
+}
+
+func injectIBMCloud(secretName string) []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{Name: "CLOUD_TYPE", Value: "ibmcloud"},
+		{Name: "IBMC_URL", ValueFrom: secretKeyRef(secretName, SecretKeyIBMCURL)},
+		{Name: "IBMC_APIKEY", ValueFrom: secretKeyRef(secretName, SecretKeyIBMCAPIKey)},
 	}
 }

--- a/pkg/cloudcreds/injection.go
+++ b/pkg/cloudcreds/injection.go
@@ -68,6 +68,7 @@ func secretKeyRef(secretName, key string) *corev1.EnvVarSource {
 
 func injectAWS(secretName string) []corev1.EnvVar {
 	return []corev1.EnvVar{
+		{Name: "CLOUD_TYPE", Value: "aws"},
 		{Name: "AWS_ACCESS_KEY_ID", ValueFrom: secretKeyRef(secretName, SecretKeyAWSAccessKeyID)},
 		{Name: "AWS_SECRET_ACCESS_KEY", ValueFrom: secretKeyRef(secretName, SecretKeyAWSSecretAccessKey)},
 		{Name: "AWS_DEFAULT_REGION", ValueFrom: secretKeyRef(secretName, SecretKeyAWSDefaultRegion)},
@@ -76,6 +77,7 @@ func injectAWS(secretName string) []corev1.EnvVar {
 
 func injectGCP(secretName string) ([]corev1.EnvVar, []corev1.Volume, []corev1.VolumeMount) {
 	envVars := []corev1.EnvVar{
+		{Name: "CLOUD_TYPE", Value: "gcp"},
 		{Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: gcpMountPath},
 	}
 
@@ -106,6 +108,7 @@ func injectGCP(secretName string) ([]corev1.EnvVar, []corev1.Volume, []corev1.Vo
 
 func injectAzure(secretName string) []corev1.EnvVar {
 	return []corev1.EnvVar{
+		{Name: "CLOUD_TYPE", Value: "azure"},
 		{Name: "AZURE_TENANT_ID", ValueFrom: secretKeyRef(secretName, SecretKeyAzureTenantID)},
 		{Name: "AZURE_CLIENT_ID", ValueFrom: secretKeyRef(secretName, SecretKeyAzureClientID)},
 		{Name: "AZURE_CLIENT_SECRET", ValueFrom: secretKeyRef(secretName, SecretKeyAzureClientSecret)},
@@ -114,12 +117,20 @@ func injectAzure(secretName string) []corev1.EnvVar {
 }
 
 func injectOpenStack(secretName string) []corev1.EnvVar {
+	optional := true
 	return []corev1.EnvVar{
+		{Name: "CLOUD_TYPE", Value: "openstack"},
 		{Name: "OS_AUTH_URL", ValueFrom: secretKeyRef(secretName, SecretKeyOSAuthURL)},
 		{Name: "OS_USERNAME", ValueFrom: secretKeyRef(secretName, SecretKeyOSUsername)},
 		{Name: "OS_PASSWORD", ValueFrom: secretKeyRef(secretName, SecretKeyOSPassword)},
 		{Name: "OS_PROJECT_NAME", ValueFrom: secretKeyRef(secretName, SecretKeyOSProjectName)},
-		{Name: "OS_DOMAIN_NAME", ValueFrom: secretKeyRef(secretName, SecretKeyOSDomainName)},
+		{Name: "OS_DOMAIN_NAME", ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+				Key:                  SecretKeyOSDomainName,
+				Optional:             &optional,
+			},
+		}},
 	}
 }
 

--- a/pkg/cloudcreds/injection.go
+++ b/pkg/cloudcreds/injection.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudcreds
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	gcpMountPath  = "/home/krkn/.gcp/service-account.json"
+	gcpVolumeName = "cloud-cred-gcp"
+)
+
+// InjectCredentials returns the env vars, volumes, and volume mounts needed to
+// inject cloud provider credentials into a scenario pod. All env vars use
+// SecretKeyRef to avoid exposing credentials as plaintext in the pod spec.
+func InjectCredentials(secret *corev1.Secret) ([]corev1.EnvVar, []corev1.Volume, []corev1.VolumeMount, error) {
+	provider := secret.Labels[ProviderTypeLabel]
+	if provider == "" {
+		return nil, nil, nil, fmt.Errorf("secret %s missing provider-type label", secret.Name)
+	}
+
+	switch provider {
+	case ProviderAWS:
+		return injectAWS(secret.Name), nil, nil, nil
+	case ProviderGCP:
+		envVars, volumes, mounts := injectGCP(secret.Name)
+		return envVars, volumes, mounts, nil
+	case ProviderAzure:
+		return injectAzure(secret.Name), nil, nil, nil
+	case ProviderOpenStack:
+		return injectOpenStack(secret.Name), nil, nil, nil
+	default:
+		return nil, nil, nil, fmt.Errorf("unsupported cloud provider: %s", provider)
+	}
+}
+
+func secretKeyRef(secretName, key string) *corev1.EnvVarSource {
+	return &corev1.EnvVarSource{
+		SecretKeyRef: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+			Key:                  key,
+		},
+	}
+}
+
+func injectAWS(secretName string) []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{Name: "AWS_ACCESS_KEY_ID", ValueFrom: secretKeyRef(secretName, SecretKeyAWSAccessKeyID)},
+		{Name: "AWS_SECRET_ACCESS_KEY", ValueFrom: secretKeyRef(secretName, SecretKeyAWSSecretAccessKey)},
+		{Name: "AWS_DEFAULT_REGION", ValueFrom: secretKeyRef(secretName, SecretKeyAWSDefaultRegion)},
+	}
+}
+
+func injectGCP(secretName string) ([]corev1.EnvVar, []corev1.Volume, []corev1.VolumeMount) {
+	envVars := []corev1.EnvVar{
+		{Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: gcpMountPath},
+	}
+
+	volumes := []corev1.Volume{
+		{
+			Name: gcpVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: secretName,
+					Items: []corev1.KeyToPath{
+						{Key: SecretKeyGCPServiceAccountJSON, Path: "service-account.json"},
+					},
+				},
+			},
+		},
+	}
+
+	mounts := []corev1.VolumeMount{
+		{
+			Name:      gcpVolumeName,
+			MountPath: "/home/krkn/.gcp",
+			ReadOnly:  true,
+		},
+	}
+
+	return envVars, volumes, mounts
+}
+
+func injectAzure(secretName string) []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{Name: "AZURE_TENANT_ID", ValueFrom: secretKeyRef(secretName, SecretKeyAzureTenantID)},
+		{Name: "AZURE_CLIENT_ID", ValueFrom: secretKeyRef(secretName, SecretKeyAzureClientID)},
+		{Name: "AZURE_CLIENT_SECRET", ValueFrom: secretKeyRef(secretName, SecretKeyAzureClientSecret)},
+		{Name: "AZURE_SUBSCRIPTION_ID", ValueFrom: secretKeyRef(secretName, SecretKeyAzureSubscriptionID)},
+	}
+}
+
+func injectOpenStack(secretName string) []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{Name: "OS_AUTH_URL", ValueFrom: secretKeyRef(secretName, SecretKeyOSAuthURL)},
+		{Name: "OS_USERNAME", ValueFrom: secretKeyRef(secretName, SecretKeyOSUsername)},
+		{Name: "OS_PASSWORD", ValueFrom: secretKeyRef(secretName, SecretKeyOSPassword)},
+		{Name: "OS_PROJECT_NAME", ValueFrom: secretKeyRef(secretName, SecretKeyOSProjectName)},
+		{Name: "OS_DOMAIN_NAME", ValueFrom: secretKeyRef(secretName, SecretKeyOSDomainName)},
+	}
+}

--- a/pkg/cloudcreds/injection_test.go
+++ b/pkg/cloudcreds/injection_test.go
@@ -237,6 +237,87 @@ func TestInjectCredentialsBaremetal(t *testing.T) {
 	}
 }
 
+func TestInjectCredentialsVMware(t *testing.T) {
+	secret := makeSecret("vmware-prod", ProviderVMware, map[string][]byte{
+		SecretKeyVSphereIP:       []byte("10.0.0.1"),
+		SecretKeyVSphereUsername: []byte("admin@vsphere.local"),
+		SecretKeyVSpherePassword: []byte("secret"),
+	})
+
+	envVars, volumes, mounts, err := InjectCredentials(secret)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(volumes) != 0 || len(mounts) != 0 {
+		t.Error("expected no volumes or mounts for VMware")
+	}
+	if len(envVars) != 4 {
+		t.Fatalf("expected 4 env vars, got %d", len(envVars))
+	}
+
+	cloudTypeFound := false
+	for _, env := range envVars {
+		if env.Name == "CLOUD_TYPE" {
+			cloudTypeFound = true
+			if env.Value != "vmware" {
+				t.Errorf("CLOUD_TYPE value = %q, want %q", env.Value, "vmware")
+			}
+		}
+	}
+	if !cloudTypeFound {
+		t.Error("expected CLOUD_TYPE env var")
+	}
+
+	for _, env := range envVars {
+		if env.Name == "CLOUD_TYPE" {
+			continue
+		}
+		if env.ValueFrom == nil || env.ValueFrom.SecretKeyRef == nil {
+			t.Errorf("env var %s should use SecretKeyRef", env.Name)
+		}
+	}
+}
+
+func TestInjectCredentialsIBMCloud(t *testing.T) {
+	secret := makeSecret("ibm-prod", ProviderIBMCloud, map[string][]byte{
+		SecretKeyIBMCURL:    []byte("https://us-south.iaas.cloud.ibm.com/v1"),
+		SecretKeyIBMCAPIKey: []byte("my-api-key"),
+	})
+
+	envVars, volumes, mounts, err := InjectCredentials(secret)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(volumes) != 0 || len(mounts) != 0 {
+		t.Error("expected no volumes or mounts for IBM Cloud")
+	}
+	if len(envVars) != 3 {
+		t.Fatalf("expected 3 env vars, got %d", len(envVars))
+	}
+
+	cloudTypeFound := false
+	for _, env := range envVars {
+		if env.Name == "CLOUD_TYPE" {
+			cloudTypeFound = true
+			if env.Value != "ibmcloud" {
+				t.Errorf("CLOUD_TYPE value = %q, want %q", env.Value, "ibmcloud")
+			}
+		}
+	}
+	if !cloudTypeFound {
+		t.Error("expected CLOUD_TYPE env var")
+	}
+
+	for _, env := range envVars {
+		if env.Name == "CLOUD_TYPE" {
+			continue
+		}
+		if env.ValueFrom == nil || env.ValueFrom.SecretKeyRef == nil {
+			t.Errorf("env var %s should use SecretKeyRef", env.Name)
+		}
+	}
+}
+
 func TestInjectCredentialsMissingProviderLabel(t *testing.T) {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cloudcreds/injection_test.go
+++ b/pkg/cloudcreds/injection_test.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudcreds
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func makeSecret(name, provider string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				ProviderTypeLabel: provider,
+			},
+		},
+		Data: data,
+	}
+}
+
+func TestInjectCredentialsAWS(t *testing.T) {
+	secret := makeSecret("aws-prod", ProviderAWS, map[string][]byte{
+		SecretKeyAWSAccessKeyID:     []byte("AKIATEST"),
+		SecretKeyAWSSecretAccessKey: []byte("secret"),
+		SecretKeyAWSDefaultRegion:   []byte("us-east-1"),
+	})
+
+	envVars, volumes, mounts, err := InjectCredentials(secret)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(volumes) != 0 {
+		t.Errorf("expected 0 volumes, got %d", len(volumes))
+	}
+	if len(mounts) != 0 {
+		t.Errorf("expected 0 mounts, got %d", len(mounts))
+	}
+	if len(envVars) != 3 {
+		t.Fatalf("expected 3 env vars, got %d", len(envVars))
+	}
+
+	expectedEnvs := map[string]string{
+		"AWS_ACCESS_KEY_ID":     SecretKeyAWSAccessKeyID,
+		"AWS_SECRET_ACCESS_KEY": SecretKeyAWSSecretAccessKey,
+		"AWS_DEFAULT_REGION":    SecretKeyAWSDefaultRegion,
+	}
+
+	for _, env := range envVars {
+		expectedKey, ok := expectedEnvs[env.Name]
+		if !ok {
+			t.Errorf("unexpected env var: %s", env.Name)
+			continue
+		}
+		if env.ValueFrom == nil || env.ValueFrom.SecretKeyRef == nil {
+			t.Errorf("env var %s should use SecretKeyRef", env.Name)
+			continue
+		}
+		if env.ValueFrom.SecretKeyRef.Name != "aws-prod" {
+			t.Errorf("env var %s secret name = %q, want %q", env.Name, env.ValueFrom.SecretKeyRef.Name, "aws-prod")
+		}
+		if env.ValueFrom.SecretKeyRef.Key != expectedKey {
+			t.Errorf("env var %s secret key = %q, want %q", env.Name, env.ValueFrom.SecretKeyRef.Key, expectedKey)
+		}
+	}
+}
+
+func TestInjectCredentialsGCP(t *testing.T) {
+	secret := makeSecret("gcp-prod", ProviderGCP, map[string][]byte{
+		SecretKeyGCPServiceAccountJSON: []byte(`{"type":"service_account"}`),
+	})
+
+	envVars, volumes, mounts, err := InjectCredentials(secret)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(envVars) != 1 {
+		t.Fatalf("expected 1 env var, got %d", len(envVars))
+	}
+	if envVars[0].Name != "GOOGLE_APPLICATION_CREDENTIALS" {
+		t.Errorf("env var name = %q, want GOOGLE_APPLICATION_CREDENTIALS", envVars[0].Name)
+	}
+	if envVars[0].Value != gcpMountPath {
+		t.Errorf("env var value = %q, want %q", envVars[0].Value, gcpMountPath)
+	}
+	if envVars[0].ValueFrom != nil {
+		t.Error("GOOGLE_APPLICATION_CREDENTIALS should use Value, not ValueFrom")
+	}
+
+	if len(volumes) != 1 {
+		t.Fatalf("expected 1 volume, got %d", len(volumes))
+	}
+	if volumes[0].Name != gcpVolumeName {
+		t.Errorf("volume name = %q, want %q", volumes[0].Name, gcpVolumeName)
+	}
+	if volumes[0].VolumeSource.Secret == nil {
+		t.Fatal("expected Secret volume source")
+	}
+	if volumes[0].VolumeSource.Secret.SecretName != "gcp-prod" {
+		t.Errorf("volume secret name = %q, want %q", volumes[0].VolumeSource.Secret.SecretName, "gcp-prod")
+	}
+
+	if len(mounts) != 1 {
+		t.Fatalf("expected 1 mount, got %d", len(mounts))
+	}
+	if mounts[0].Name != gcpVolumeName {
+		t.Errorf("mount name = %q, want %q", mounts[0].Name, gcpVolumeName)
+	}
+	if mounts[0].MountPath != "/home/krkn/.gcp" {
+		t.Errorf("mount path = %q, want %q", mounts[0].MountPath, "/home/krkn/.gcp")
+	}
+	if !mounts[0].ReadOnly {
+		t.Error("expected mount to be read-only")
+	}
+}
+
+func TestInjectCredentialsAzure(t *testing.T) {
+	secret := makeSecret("azure-prod", ProviderAzure, map[string][]byte{
+		SecretKeyAzureTenantID:       []byte("tenant"),
+		SecretKeyAzureClientID:       []byte("client"),
+		SecretKeyAzureClientSecret:   []byte("secret"),
+		SecretKeyAzureSubscriptionID: []byte("sub"),
+	})
+
+	envVars, volumes, mounts, err := InjectCredentials(secret)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(volumes) != 0 || len(mounts) != 0 {
+		t.Error("expected no volumes or mounts for Azure")
+	}
+	if len(envVars) != 4 {
+		t.Fatalf("expected 4 env vars, got %d", len(envVars))
+	}
+
+	for _, env := range envVars {
+		if env.ValueFrom == nil || env.ValueFrom.SecretKeyRef == nil {
+			t.Errorf("env var %s should use SecretKeyRef", env.Name)
+		}
+		if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil && env.ValueFrom.SecretKeyRef.Name != "azure-prod" {
+			t.Errorf("env var %s secret name = %q, want %q", env.Name, env.ValueFrom.SecretKeyRef.Name, "azure-prod")
+		}
+	}
+}
+
+func TestInjectCredentialsOpenStack(t *testing.T) {
+	secret := makeSecret("os-prod", ProviderOpenStack, map[string][]byte{
+		SecretKeyOSAuthURL:     []byte("http://auth:5000"),
+		SecretKeyOSUsername:    []byte("admin"),
+		SecretKeyOSPassword:    []byte("pass"),
+		SecretKeyOSProjectName: []byte("project"),
+		SecretKeyOSDomainName:  []byte("Default"),
+	})
+
+	envVars, volumes, mounts, err := InjectCredentials(secret)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(volumes) != 0 || len(mounts) != 0 {
+		t.Error("expected no volumes or mounts for OpenStack")
+	}
+	if len(envVars) != 5 {
+		t.Fatalf("expected 5 env vars, got %d", len(envVars))
+	}
+
+	for _, env := range envVars {
+		if env.ValueFrom == nil || env.ValueFrom.SecretKeyRef == nil {
+			t.Errorf("env var %s should use SecretKeyRef", env.Name)
+		}
+	}
+}
+
+func TestInjectCredentialsMissingProviderLabel(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "bad",
+			Labels: map[string]string{},
+		},
+	}
+
+	_, _, _, err := InjectCredentials(secret)
+	if err == nil {
+		t.Fatal("expected error for missing provider label")
+	}
+	if !strings.Contains(err.Error(), "missing provider-type label") {
+		t.Errorf("error = %q, want it to mention missing provider label", err.Error())
+	}
+}
+
+func TestInjectCredentialsUnsupportedProvider(t *testing.T) {
+	secret := makeSecret("bad", "oracle", nil)
+
+	_, _, _, err := InjectCredentials(secret)
+	if err == nil {
+		t.Fatal("expected error for unsupported provider")
+	}
+	if !strings.Contains(err.Error(), "unsupported cloud provider") {
+		t.Errorf("error = %q, want it to mention unsupported provider", err.Error())
+	}
+}

--- a/pkg/cloudcreds/injection_test.go
+++ b/pkg/cloudcreds/injection_test.go
@@ -53,8 +53,8 @@ func TestInjectCredentialsAWS(t *testing.T) {
 	if len(mounts) != 0 {
 		t.Errorf("expected 0 mounts, got %d", len(mounts))
 	}
-	if len(envVars) != 3 {
-		t.Fatalf("expected 3 env vars, got %d", len(envVars))
+	if len(envVars) != 4 {
+		t.Fatalf("expected 4 env vars (CLOUD_TYPE + 3 AWS), got %d", len(envVars))
 	}
 
 	expectedEnvs := map[string]string{
@@ -64,6 +64,12 @@ func TestInjectCredentialsAWS(t *testing.T) {
 	}
 
 	for _, env := range envVars {
+		if env.Name == "CLOUD_TYPE" {
+			if env.Value != "aws" {
+				t.Errorf("CLOUD_TYPE = %q, want %q", env.Value, "aws")
+			}
+			continue
+		}
 		expectedKey, ok := expectedEnvs[env.Name]
 		if !ok {
 			t.Errorf("unexpected env var: %s", env.Name)
@@ -92,16 +98,19 @@ func TestInjectCredentialsGCP(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(envVars) != 1 {
-		t.Fatalf("expected 1 env var, got %d", len(envVars))
+	if len(envVars) != 2 {
+		t.Fatalf("expected 2 env vars (CLOUD_TYPE + GOOGLE_APPLICATION_CREDENTIALS), got %d", len(envVars))
 	}
-	if envVars[0].Name != "GOOGLE_APPLICATION_CREDENTIALS" {
-		t.Errorf("env var name = %q, want GOOGLE_APPLICATION_CREDENTIALS", envVars[0].Name)
+	if envVars[0].Name != "CLOUD_TYPE" || envVars[0].Value != "gcp" {
+		t.Errorf("first env var = %q=%q, want CLOUD_TYPE=gcp", envVars[0].Name, envVars[0].Value)
 	}
-	if envVars[0].Value != gcpMountPath {
-		t.Errorf("env var value = %q, want %q", envVars[0].Value, gcpMountPath)
+	if envVars[1].Name != "GOOGLE_APPLICATION_CREDENTIALS" {
+		t.Errorf("env var name = %q, want GOOGLE_APPLICATION_CREDENTIALS", envVars[1].Name)
 	}
-	if envVars[0].ValueFrom != nil {
+	if envVars[1].Value != gcpMountPath {
+		t.Errorf("env var value = %q, want %q", envVars[1].Value, gcpMountPath)
+	}
+	if envVars[1].ValueFrom != nil {
 		t.Error("GOOGLE_APPLICATION_CREDENTIALS should use Value, not ValueFrom")
 	}
 
@@ -147,11 +156,17 @@ func TestInjectCredentialsAzure(t *testing.T) {
 	if len(volumes) != 0 || len(mounts) != 0 {
 		t.Error("expected no volumes or mounts for Azure")
 	}
-	if len(envVars) != 4 {
-		t.Fatalf("expected 4 env vars, got %d", len(envVars))
+	if len(envVars) != 5 {
+		t.Fatalf("expected 5 env vars (CLOUD_TYPE + 4 Azure), got %d", len(envVars))
 	}
 
 	for _, env := range envVars {
+		if env.Name == "CLOUD_TYPE" {
+			if env.Value != "azure" {
+				t.Errorf("CLOUD_TYPE = %q, want %q", env.Value, "azure")
+			}
+			continue
+		}
 		if env.ValueFrom == nil || env.ValueFrom.SecretKeyRef == nil {
 			t.Errorf("env var %s should use SecretKeyRef", env.Name)
 		}
@@ -177,13 +192,22 @@ func TestInjectCredentialsOpenStack(t *testing.T) {
 	if len(volumes) != 0 || len(mounts) != 0 {
 		t.Error("expected no volumes or mounts for OpenStack")
 	}
-	if len(envVars) != 5 {
-		t.Fatalf("expected 5 env vars, got %d", len(envVars))
+	if len(envVars) != 6 {
+		t.Fatalf("expected 6 env vars (CLOUD_TYPE + 5 OpenStack), got %d", len(envVars))
 	}
 
 	for _, env := range envVars {
+		if env.Name == "CLOUD_TYPE" {
+			if env.Value != "openstack" {
+				t.Errorf("CLOUD_TYPE = %q, want %q", env.Value, "openstack")
+			}
+			continue
+		}
 		if env.ValueFrom == nil || env.ValueFrom.SecretKeyRef == nil {
 			t.Errorf("env var %s should use SecretKeyRef", env.Name)
+		}
+		if env.Name == "OS_DOMAIN_NAME" && env.ValueFrom.SecretKeyRef.Optional == nil {
+			t.Error("OS_DOMAIN_NAME SecretKeyRef should have Optional set")
 		}
 	}
 }

--- a/pkg/cloudcreds/injection_test.go
+++ b/pkg/cloudcreds/injection_test.go
@@ -188,6 +188,55 @@ func TestInjectCredentialsOpenStack(t *testing.T) {
 	}
 }
 
+func TestInjectCredentialsBaremetal(t *testing.T) {
+	secret := makeSecret("bm-prod", ProviderBaremetal, map[string][]byte{
+		SecretKeyBMCUser:     []byte("admin"),
+		SecretKeyBMCPassword: []byte("secret"),
+		SecretKeyBMCAddr:     []byte("192.168.1.100"),
+	})
+
+	envVars, volumes, mounts, err := InjectCredentials(secret)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(volumes) != 0 || len(mounts) != 0 {
+		t.Error("expected no volumes or mounts for Baremetal")
+	}
+	if len(envVars) != 4 {
+		t.Fatalf("expected 4 env vars, got %d", len(envVars))
+	}
+
+	// CLOUD_TYPE should be a plain value, not SecretKeyRef
+	cloudTypeFound := false
+	for _, env := range envVars {
+		if env.Name == "CLOUD_TYPE" {
+			cloudTypeFound = true
+			if env.Value != "bm" {
+				t.Errorf("CLOUD_TYPE value = %q, want %q", env.Value, "bm")
+			}
+			if env.ValueFrom != nil {
+				t.Error("CLOUD_TYPE should use Value, not ValueFrom")
+			}
+		}
+	}
+	if !cloudTypeFound {
+		t.Error("expected CLOUD_TYPE env var")
+	}
+
+	// BMC_USER, BMC_PASSWORD, BMC_ADDR should use SecretKeyRef
+	for _, env := range envVars {
+		if env.Name == "CLOUD_TYPE" {
+			continue
+		}
+		if env.ValueFrom == nil || env.ValueFrom.SecretKeyRef == nil {
+			t.Errorf("env var %s should use SecretKeyRef", env.Name)
+		}
+		if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil && env.ValueFrom.SecretKeyRef.Name != "bm-prod" {
+			t.Errorf("env var %s secret name = %q, want %q", env.Name, env.ValueFrom.SecretKeyRef.Name, "bm-prod")
+		}
+	}
+}
+
 func TestInjectCredentialsMissingProviderLabel(t *testing.T) {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cloudcreds/labels.go
+++ b/pkg/cloudcreds/labels.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudcreds
+
+import (
+	"strings"
+	"time"
+
+	"github.com/krkn-chaos/krkn-operator/pkg/groupauth"
+)
+
+// Label and annotation keys for cloud credential Secrets
+const (
+	AppNameLabel      = "app.kubernetes.io/name"
+	AppComponentLabel = "app.kubernetes.io/component"
+
+	ProviderTypeLabel   = "cloudcreds.krkn.krkn-chaos.dev/provider-type"
+	AvailableToAllLabel = "cloudcreds.krkn.krkn-chaos.dev/available-to-all"
+
+	DescriptionAnnotation = "cloudcreds.krkn.krkn-chaos.dev/description"
+	CreatedByAnnotation   = "cloudcreds.krkn.krkn-chaos.dev/created-by"
+	CreatedAtAnnotation   = "cloudcreds.krkn.krkn-chaos.dev/created-at"
+	UpdatedByAnnotation   = "cloudcreds.krkn.krkn-chaos.dev/updated-by"
+	UpdatedAtAnnotation   = "cloudcreds.krkn.krkn-chaos.dev/updated-at"
+
+	AppName                  = "krkn-operator"
+	ComponentCloudCredential = "cloud-credential"
+)
+
+// BuildLabels creates the labels map for a cloud credential Secret
+func BuildLabels(provider string, groups []string, availableToAll bool) map[string]string {
+	labels := map[string]string{
+		AppNameLabel:      AppName,
+		AppComponentLabel: ComponentCloudCredential,
+		ProviderTypeLabel: provider,
+	}
+
+	if availableToAll {
+		labels[AvailableToAllLabel] = "true"
+	}
+
+	for _, groupName := range groups {
+		groupLabel := groupauth.GroupLabelKey(groupName)
+		labels[groupLabel] = "true"
+	}
+
+	return labels
+}
+
+// BuildAnnotations creates the annotations map for a cloud credential Secret
+func BuildAnnotations(description, createdBy string) map[string]string {
+	annotations := map[string]string{
+		CreatedByAnnotation: createdBy,
+		CreatedAtAnnotation: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	if description != "" {
+		annotations[DescriptionAnnotation] = description
+	}
+
+	return annotations
+}
+
+// UpdateAnnotations updates the annotations for a cloud credential Secret
+func UpdateAnnotations(existing map[string]string, description, updatedBy string) map[string]string {
+	updated := make(map[string]string)
+	for k, v := range existing {
+		updated[k] = v
+	}
+
+	updated[UpdatedByAnnotation] = updatedBy
+	updated[UpdatedAtAnnotation] = time.Now().UTC().Format(time.RFC3339)
+
+	if description != "" {
+		updated[DescriptionAnnotation] = description
+	} else {
+		delete(updated, DescriptionAnnotation)
+	}
+
+	return updated
+}
+
+// ExtractGroupsFromLabels extracts group names from cloud credential Secret labels
+func ExtractGroupsFromLabels(labels map[string]string) []string {
+	groups := []string{}
+
+	for key, value := range labels {
+		if strings.HasPrefix(key, groupauth.GroupLabelPrefix) && value == "true" {
+			groupName := strings.TrimPrefix(key, groupauth.GroupLabelPrefix)
+			groups = append(groups, groupName)
+		}
+	}
+
+	return groups
+}

--- a/pkg/cloudcreds/labels_test.go
+++ b/pkg/cloudcreds/labels_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudcreds
+
+import (
+	"testing"
+
+	"github.com/krkn-chaos/krkn-operator/pkg/groupauth"
+)
+
+func TestBuildLabels(t *testing.T) {
+	tests := []struct {
+		name           string
+		provider       string
+		groups         []string
+		availableToAll bool
+		wantProvider   string
+		wantGroups     int
+		wantAvailable  bool
+	}{
+		{
+			name:         "aws no groups",
+			provider:     ProviderAWS,
+			groups:       nil,
+			wantProvider: ProviderAWS,
+		},
+		{
+			name:         "gcp with groups",
+			provider:     ProviderGCP,
+			groups:       []string{"team-a", "team-b"},
+			wantProvider: ProviderGCP,
+			wantGroups:   2,
+		},
+		{
+			name:           "azure available to all",
+			provider:       ProviderAzure,
+			availableToAll: true,
+			wantProvider:   ProviderAzure,
+			wantAvailable:  true,
+		},
+		{
+			name:           "openstack with groups and available to all",
+			provider:       ProviderOpenStack,
+			groups:         []string{"ops"},
+			availableToAll: true,
+			wantProvider:   ProviderOpenStack,
+			wantGroups:     1,
+			wantAvailable:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			labels := BuildLabels(tt.provider, tt.groups, tt.availableToAll)
+
+			if labels[AppNameLabel] != AppName {
+				t.Errorf("AppNameLabel = %q, want %q", labels[AppNameLabel], AppName)
+			}
+			if labels[AppComponentLabel] != ComponentCloudCredential {
+				t.Errorf("AppComponentLabel = %q, want %q", labels[AppComponentLabel], ComponentCloudCredential)
+			}
+			if labels[ProviderTypeLabel] != tt.wantProvider {
+				t.Errorf("ProviderTypeLabel = %q, want %q", labels[ProviderTypeLabel], tt.wantProvider)
+			}
+
+			if tt.wantAvailable {
+				if labels[AvailableToAllLabel] != "true" {
+					t.Error("expected AvailableToAllLabel to be 'true'")
+				}
+			} else {
+				if _, ok := labels[AvailableToAllLabel]; ok {
+					t.Error("expected AvailableToAllLabel to be absent")
+				}
+			}
+
+			groupCount := 0
+			for key, value := range labels {
+				if len(key) > len(groupauth.GroupLabelPrefix) && key[:len(groupauth.GroupLabelPrefix)] == groupauth.GroupLabelPrefix && value == "true" {
+					groupCount++
+				}
+			}
+			if groupCount != tt.wantGroups {
+				t.Errorf("group label count = %d, want %d", groupCount, tt.wantGroups)
+			}
+		})
+	}
+}
+
+func TestBuildAnnotations(t *testing.T) {
+	annotations := BuildAnnotations("test cloud creds", "admin@example.com")
+
+	if annotations[CreatedByAnnotation] != "admin@example.com" {
+		t.Errorf("CreatedBy = %q, want %q", annotations[CreatedByAnnotation], "admin@example.com")
+	}
+	if annotations[CreatedAtAnnotation] == "" {
+		t.Error("expected CreatedAt to be set")
+	}
+	if annotations[DescriptionAnnotation] != "test cloud creds" {
+		t.Errorf("Description = %q, want %q", annotations[DescriptionAnnotation], "test cloud creds")
+	}
+}
+
+func TestBuildAnnotationsNoDescription(t *testing.T) {
+	annotations := BuildAnnotations("", "admin@example.com")
+
+	if _, ok := annotations[DescriptionAnnotation]; ok {
+		t.Error("expected DescriptionAnnotation to be absent when description is empty")
+	}
+}
+
+func TestUpdateAnnotations(t *testing.T) {
+	existing := map[string]string{
+		CreatedByAnnotation:   "original@example.com",
+		CreatedAtAnnotation:   "2026-01-01T00:00:00Z",
+		DescriptionAnnotation: "old desc",
+	}
+
+	updated := UpdateAnnotations(existing, "new desc", "updater@example.com")
+
+	if updated[CreatedByAnnotation] != "original@example.com" {
+		t.Error("expected CreatedBy to be preserved")
+	}
+	if updated[CreatedAtAnnotation] != "2026-01-01T00:00:00Z" {
+		t.Error("expected CreatedAt to be preserved")
+	}
+	if updated[UpdatedByAnnotation] != "updater@example.com" {
+		t.Errorf("UpdatedBy = %q, want %q", updated[UpdatedByAnnotation], "updater@example.com")
+	}
+	if updated[UpdatedAtAnnotation] == "" {
+		t.Error("expected UpdatedAt to be set")
+	}
+	if updated[DescriptionAnnotation] != "new desc" {
+		t.Errorf("Description = %q, want %q", updated[DescriptionAnnotation], "new desc")
+	}
+}
+
+func TestUpdateAnnotationsClearsDescription(t *testing.T) {
+	existing := map[string]string{
+		DescriptionAnnotation: "old desc",
+	}
+
+	updated := UpdateAnnotations(existing, "", "updater@example.com")
+
+	if _, ok := updated[DescriptionAnnotation]; ok {
+		t.Error("expected DescriptionAnnotation to be removed when empty")
+	}
+}
+
+func TestExtractGroupsFromLabels(t *testing.T) {
+	labels := map[string]string{
+		AppNameLabel:                      AppName,
+		AppComponentLabel:                 ComponentCloudCredential,
+		groupauth.GroupLabelKey("team-a"): "true",
+		groupauth.GroupLabelKey("team-b"): "true",
+		groupauth.GroupLabelKey("team-c"): "false",
+	}
+
+	groups := ExtractGroupsFromLabels(labels)
+
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(groups))
+	}
+
+	groupSet := make(map[string]bool)
+	for _, g := range groups {
+		groupSet[g] = true
+	}
+	if !groupSet["team-a"] || !groupSet["team-b"] {
+		t.Errorf("expected groups [team-a, team-b], got %v", groups)
+	}
+}

--- a/pkg/cloudcreds/types.go
+++ b/pkg/cloudcreds/types.go
@@ -26,6 +26,7 @@ const (
 	ProviderGCP       = "gcp"
 	ProviderAzure     = "azure"
 	ProviderOpenStack = "openstack"
+	ProviderBaremetal = "baremetal"
 )
 
 // Secret data key constants for each provider
@@ -50,6 +51,11 @@ const (
 	SecretKeyOSPassword    = "os-password"
 	SecretKeyOSProjectName = "os-project-name"
 	SecretKeyOSDomainName  = "os-domain-name"
+
+	// Baremetal (IPMI/BMC)
+	SecretKeyBMCUser     = "bmc-user"
+	SecretKeyBMCPassword = "bmc-password"
+	SecretKeyBMCAddr     = "bmc-addr"
 )
 
 // CreateCloudCredentialRequest represents the request to create a cloud credential config
@@ -80,6 +86,11 @@ type CreateCloudCredentialRequest struct {
 	OSPassword    string `json:"osPassword,omitempty"`
 	OSProjectName string `json:"osProjectName,omitempty"`
 	OSDomainName  string `json:"osDomainName,omitempty"`
+
+	// Baremetal (IPMI/BMC) fields
+	BMCUser     string `json:"bmcUser,omitempty"`
+	BMCPassword string `json:"bmcPassword,omitempty"`
+	BMCAddr     string `json:"bmcAddr,omitempty"`
 }
 
 // UpdateCloudCredentialRequest represents the request to update a cloud credential config.
@@ -109,6 +120,11 @@ type UpdateCloudCredentialRequest struct {
 	OSPassword    string `json:"osPassword,omitempty"`
 	OSProjectName string `json:"osProjectName,omitempty"`
 	OSDomainName  string `json:"osDomainName,omitempty"`
+
+	// Baremetal (IPMI/BMC) fields
+	BMCUser     string `json:"bmcUser,omitempty"`
+	BMCPassword string `json:"bmcPassword,omitempty"`
+	BMCAddr     string `json:"bmcAddr,omitempty"`
 }
 
 // CloudCredentialResponse represents a cloud credential in API responses.
@@ -154,4 +170,5 @@ var ValidProviders = map[string]bool{
 	ProviderGCP:       true,
 	ProviderAzure:     true,
 	ProviderOpenStack: true,
+	ProviderBaremetal: true,
 }

--- a/pkg/cloudcreds/types.go
+++ b/pkg/cloudcreds/types.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cloudcreds provides functionality for managing cloud provider
+// credentials in the krkn-operator ecosystem. Credentials are stored as
+// Kubernetes Secrets with labeled metadata and injected into scenario pods
+// via SecretKeyRef env vars and SecretVolumeSource file mounts.
+package cloudcreds
+
+// Cloud provider constants
+const (
+	ProviderAWS       = "aws"
+	ProviderGCP       = "gcp"
+	ProviderAzure     = "azure"
+	ProviderOpenStack = "openstack"
+)
+
+// Secret data key constants for each provider
+const (
+	// AWS
+	SecretKeyAWSAccessKeyID     = "aws-access-key-id"
+	SecretKeyAWSSecretAccessKey = "aws-secret-access-key"
+	SecretKeyAWSDefaultRegion   = "aws-default-region"
+
+	// GCP
+	SecretKeyGCPServiceAccountJSON = "gcp-service-account-json"
+
+	// Azure
+	SecretKeyAzureTenantID       = "azure-tenant-id"
+	SecretKeyAzureClientID       = "azure-client-id"
+	SecretKeyAzureClientSecret   = "azure-client-secret"
+	SecretKeyAzureSubscriptionID = "azure-subscription-id"
+
+	// OpenStack
+	SecretKeyOSAuthURL     = "os-auth-url"
+	SecretKeyOSUsername    = "os-username"
+	SecretKeyOSPassword    = "os-password"
+	SecretKeyOSProjectName = "os-project-name"
+	SecretKeyOSDomainName  = "os-domain-name"
+)
+
+// CreateCloudCredentialRequest represents the request to create a cloud credential config
+type CreateCloudCredentialRequest struct {
+	Name           string   `json:"name"`
+	Provider       string   `json:"provider"`
+	Description    string   `json:"description,omitempty"`
+	Groups         []string `json:"groups,omitempty"`
+	AvailableToAll bool     `json:"availableToAll,omitempty"`
+
+	// AWS fields
+	AWSAccessKeyID     string `json:"awsAccessKeyId,omitempty"`
+	AWSSecretAccessKey string `json:"awsSecretAccessKey,omitempty"`
+	AWSDefaultRegion   string `json:"awsDefaultRegion,omitempty"`
+
+	// GCP fields
+	GCPServiceAccountJSON string `json:"gcpServiceAccountJson,omitempty"`
+
+	// Azure fields
+	AzureTenantID       string `json:"azureTenantId,omitempty"`
+	AzureClientID       string `json:"azureClientId,omitempty"`
+	AzureClientSecret   string `json:"azureClientSecret,omitempty"`
+	AzureSubscriptionID string `json:"azureSubscriptionId,omitempty"`
+
+	// OpenStack fields
+	OSAuthURL     string `json:"osAuthUrl,omitempty"`
+	OSUsername    string `json:"osUsername,omitempty"`
+	OSPassword    string `json:"osPassword,omitempty"`
+	OSProjectName string `json:"osProjectName,omitempty"`
+	OSDomainName  string `json:"osDomainName,omitempty"`
+}
+
+// UpdateCloudCredentialRequest represents the request to update a cloud credential config.
+// Provider is immutable and cannot be changed after creation.
+type UpdateCloudCredentialRequest struct {
+	Description    string   `json:"description,omitempty"`
+	Groups         []string `json:"groups,omitempty"`
+	AvailableToAll bool     `json:"availableToAll,omitempty"`
+
+	// AWS fields
+	AWSAccessKeyID     string `json:"awsAccessKeyId,omitempty"`
+	AWSSecretAccessKey string `json:"awsSecretAccessKey,omitempty"`
+	AWSDefaultRegion   string `json:"awsDefaultRegion,omitempty"`
+
+	// GCP fields
+	GCPServiceAccountJSON string `json:"gcpServiceAccountJson,omitempty"`
+
+	// Azure fields
+	AzureTenantID       string `json:"azureTenantId,omitempty"`
+	AzureClientID       string `json:"azureClientId,omitempty"`
+	AzureClientSecret   string `json:"azureClientSecret,omitempty"`
+	AzureSubscriptionID string `json:"azureSubscriptionId,omitempty"`
+
+	// OpenStack fields
+	OSAuthURL     string `json:"osAuthUrl,omitempty"`
+	OSUsername    string `json:"osUsername,omitempty"`
+	OSPassword    string `json:"osPassword,omitempty"`
+	OSProjectName string `json:"osProjectName,omitempty"`
+	OSDomainName  string `json:"osDomainName,omitempty"`
+}
+
+// CloudCredentialResponse represents a cloud credential in API responses.
+// Secret data is intentionally never included.
+type CloudCredentialResponse struct {
+	Name           string   `json:"name"`
+	Provider       string   `json:"provider"`
+	Description    string   `json:"description,omitempty"`
+	Groups         []string `json:"groups,omitempty"`
+	AvailableToAll bool     `json:"availableToAll,omitempty"`
+	CreatedAt      string   `json:"createdAt,omitempty"`
+	CreatedBy      string   `json:"createdBy,omitempty"`
+	UpdatedAt      string   `json:"updatedAt,omitempty"`
+	UpdatedBy      string   `json:"updatedBy,omitempty"`
+}
+
+// ListCloudCredentialsResponse represents the response for listing cloud credentials
+type ListCloudCredentialsResponse struct {
+	Credentials []CloudCredentialResponse `json:"credentials"`
+	Total       int                       `json:"total"`
+}
+
+// CreateCloudCredentialResponse represents the response after creating a cloud credential
+type CreateCloudCredentialResponse struct {
+	Message string `json:"message"`
+	Name    string `json:"name"`
+}
+
+// UpdateCloudCredentialResponse represents the response after updating a cloud credential
+type UpdateCloudCredentialResponse struct {
+	Message string `json:"message"`
+	Name    string `json:"name"`
+}
+
+// DeleteCloudCredentialResponse represents the response after deleting a cloud credential
+type DeleteCloudCredentialResponse struct {
+	Message string `json:"message"`
+}
+
+// ValidProviders is the set of supported cloud provider types
+var ValidProviders = map[string]bool{
+	ProviderAWS:       true,
+	ProviderGCP:       true,
+	ProviderAzure:     true,
+	ProviderOpenStack: true,
+}

--- a/pkg/cloudcreds/types.go
+++ b/pkg/cloudcreds/types.go
@@ -27,6 +27,8 @@ const (
 	ProviderAzure     = "azure"
 	ProviderOpenStack = "openstack"
 	ProviderBaremetal = "baremetal"
+	ProviderVMware    = "vmware"
+	ProviderIBMCloud  = "ibmcloud"
 )
 
 // Secret data key constants for each provider
@@ -56,6 +58,15 @@ const (
 	SecretKeyBMCUser     = "bmc-user"
 	SecretKeyBMCPassword = "bmc-password"
 	SecretKeyBMCAddr     = "bmc-addr"
+
+	// VMware vSphere
+	SecretKeyVSphereIP       = "vsphere-ip"
+	SecretKeyVSphereUsername = "vsphere-username"
+	SecretKeyVSpherePassword = "vsphere-password"
+
+	// IBM Cloud
+	SecretKeyIBMCURL    = "ibmc-url"
+	SecretKeyIBMCAPIKey = "ibmc-apikey"
 )
 
 // CreateCloudCredentialRequest represents the request to create a cloud credential config
@@ -91,6 +102,15 @@ type CreateCloudCredentialRequest struct {
 	BMCUser     string `json:"bmcUser,omitempty"`
 	BMCPassword string `json:"bmcPassword,omitempty"`
 	BMCAddr     string `json:"bmcAddr,omitempty"`
+
+	// VMware vSphere fields
+	VSphereIP       string `json:"vsphereIp,omitempty"`
+	VSphereUsername string `json:"vsphereUsername,omitempty"`
+	VSpherePassword string `json:"vspherePassword,omitempty"`
+
+	// IBM Cloud fields
+	IBMCURL    string `json:"ibmcUrl,omitempty"`
+	IBMCAPIKey string `json:"ibmcApikey,omitempty"`
 }
 
 // UpdateCloudCredentialRequest represents the request to update a cloud credential config.
@@ -125,6 +145,15 @@ type UpdateCloudCredentialRequest struct {
 	BMCUser     string `json:"bmcUser,omitempty"`
 	BMCPassword string `json:"bmcPassword,omitempty"`
 	BMCAddr     string `json:"bmcAddr,omitempty"`
+
+	// VMware vSphere fields
+	VSphereIP       string `json:"vsphereIp,omitempty"`
+	VSphereUsername string `json:"vsphereUsername,omitempty"`
+	VSpherePassword string `json:"vspherePassword,omitempty"`
+
+	// IBM Cloud fields
+	IBMCURL    string `json:"ibmcUrl,omitempty"`
+	IBMCAPIKey string `json:"ibmcApikey,omitempty"`
 }
 
 // CloudCredentialResponse represents a cloud credential in API responses.
@@ -171,4 +200,6 @@ var ValidProviders = map[string]bool{
 	ProviderAzure:     true,
 	ProviderOpenStack: true,
 	ProviderBaremetal: true,
+	ProviderVMware:    true,
+	ProviderIBMCloud:  true,
 }

--- a/pkg/cloudcreds/validate.go
+++ b/pkg/cloudcreds/validate.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudcreds
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+)
+
+// reservedNames are credential names that would collide with API sub-path routes
+var reservedNames = map[string]bool{
+	"available": true,
+}
+
+// ValidateCreateRequest validates a CreateCloudCredentialRequest
+func ValidateCreateRequest(req *CreateCloudCredentialRequest) error {
+	if req.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+	if reservedNames[req.Name] {
+		return fmt.Errorf("name '%s' is reserved and cannot be used", req.Name)
+	}
+	if req.Provider == "" {
+		return fmt.Errorf("provider is required")
+	}
+	if !ValidProviders[req.Provider] {
+		return fmt.Errorf("provider must be one of: aws, gcp, azure, openstack")
+	}
+
+	return validateProviderFields(req.Provider, req.AWSAccessKeyID, req.AWSSecretAccessKey, req.AWSDefaultRegion,
+		req.GCPServiceAccountJSON,
+		req.AzureTenantID, req.AzureClientID, req.AzureClientSecret, req.AzureSubscriptionID,
+		req.OSAuthURL, req.OSUsername, req.OSPassword, req.OSProjectName)
+}
+
+// ValidateUpdateRequest validates an UpdateCloudCredentialRequest against the existing provider
+func ValidateUpdateRequest(req *UpdateCloudCredentialRequest, existingProvider string) error {
+	return validateProviderFieldsForUpdate(existingProvider,
+		req.AWSAccessKeyID, req.AWSSecretAccessKey, req.AWSDefaultRegion,
+		req.GCPServiceAccountJSON,
+		req.AzureTenantID, req.AzureClientID, req.AzureClientSecret, req.AzureSubscriptionID,
+		req.OSAuthURL, req.OSUsername, req.OSPassword, req.OSProjectName)
+}
+
+func validateProviderFields(provider string,
+	awsKeyID, awsSecret, awsRegion string,
+	gcpJSON string,
+	azTenant, azClient, azSecret, azSub string,
+	osAuth, osUser, osPass, osProject string,
+) error {
+	switch provider {
+	case ProviderAWS:
+		if awsKeyID == "" {
+			return fmt.Errorf("awsAccessKeyId is required for AWS provider")
+		}
+		if awsSecret == "" {
+			return fmt.Errorf("awsSecretAccessKey is required for AWS provider")
+		}
+		if awsRegion == "" {
+			return fmt.Errorf("awsDefaultRegion is required for AWS provider")
+		}
+	case ProviderGCP:
+		if gcpJSON == "" {
+			return fmt.Errorf("gcpServiceAccountJson is required for GCP provider")
+		}
+		if err := validateGCPServiceAccountJSON(gcpJSON); err != nil {
+			return fmt.Errorf("invalid gcpServiceAccountJson: %w", err)
+		}
+	case ProviderAzure:
+		if azTenant == "" {
+			return fmt.Errorf("azureTenantId is required for Azure provider")
+		}
+		if azClient == "" {
+			return fmt.Errorf("azureClientId is required for Azure provider")
+		}
+		if azSecret == "" {
+			return fmt.Errorf("azureClientSecret is required for Azure provider")
+		}
+		if azSub == "" {
+			return fmt.Errorf("azureSubscriptionId is required for Azure provider")
+		}
+	case ProviderOpenStack:
+		if osAuth == "" {
+			return fmt.Errorf("osAuthUrl is required for OpenStack provider")
+		}
+		if osUser == "" {
+			return fmt.Errorf("osUsername is required for OpenStack provider")
+		}
+		if osPass == "" {
+			return fmt.Errorf("osPassword is required for OpenStack provider")
+		}
+		if osProject == "" {
+			return fmt.Errorf("osProjectName is required for OpenStack provider")
+		}
+	}
+	return nil
+}
+
+// validateProviderFieldsForUpdate validates fields for an update request.
+// On update, fields are optional (empty means "keep existing"), so we only
+// validate non-empty values.
+func validateProviderFieldsForUpdate(provider string,
+	awsKeyID, awsSecret, awsRegion string,
+	gcpJSON string,
+	azTenant, azClient, azSecret, azSub string,
+	osAuth, osUser, osPass, osProject string,
+) error {
+	if provider == ProviderGCP && gcpJSON != "" {
+		if err := validateGCPServiceAccountJSON(gcpJSON); err != nil {
+			return fmt.Errorf("invalid gcpServiceAccountJson: %w", err)
+		}
+	}
+	return nil
+}
+
+func validateGCPServiceAccountJSON(encoded string) error {
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return fmt.Errorf("must be valid base64: %w", err)
+	}
+
+	var sa map[string]interface{}
+	if err := json.Unmarshal(decoded, &sa); err != nil {
+		return fmt.Errorf("must be valid JSON: %w", err)
+	}
+
+	if _, ok := sa["type"]; !ok {
+		return fmt.Errorf("missing required field 'type'")
+	}
+	if _, ok := sa["project_id"]; !ok {
+		return fmt.Errorf("missing required field 'project_id'")
+	}
+
+	return nil
+}

--- a/pkg/cloudcreds/validate.go
+++ b/pkg/cloudcreds/validate.go
@@ -25,6 +25,11 @@ import (
 // reservedNames are credential names that would collide with API sub-path routes
 var reservedNames = map[string]bool{
 	"available": true,
+	"aws":       true,
+	"gcp":       true,
+	"azure":     true,
+	"openstack": true,
+	"baremetal": true,
 }
 
 // ValidateCreateRequest validates a CreateCloudCredentialRequest
@@ -45,7 +50,8 @@ func ValidateCreateRequest(req *CreateCloudCredentialRequest) error {
 	return validateProviderFields(req.Provider, req.AWSAccessKeyID, req.AWSSecretAccessKey, req.AWSDefaultRegion,
 		req.GCPServiceAccountJSON,
 		req.AzureTenantID, req.AzureClientID, req.AzureClientSecret, req.AzureSubscriptionID,
-		req.OSAuthURL, req.OSUsername, req.OSPassword, req.OSProjectName)
+		req.OSAuthURL, req.OSUsername, req.OSPassword, req.OSProjectName,
+		req.BMCUser, req.BMCPassword, req.BMCAddr)
 }
 
 // ValidateUpdateRequest validates an UpdateCloudCredentialRequest against the existing provider
@@ -54,7 +60,8 @@ func ValidateUpdateRequest(req *UpdateCloudCredentialRequest, existingProvider s
 		req.AWSAccessKeyID, req.AWSSecretAccessKey, req.AWSDefaultRegion,
 		req.GCPServiceAccountJSON,
 		req.AzureTenantID, req.AzureClientID, req.AzureClientSecret, req.AzureSubscriptionID,
-		req.OSAuthURL, req.OSUsername, req.OSPassword, req.OSProjectName)
+		req.OSAuthURL, req.OSUsername, req.OSPassword, req.OSProjectName,
+		req.BMCUser, req.BMCPassword, req.BMCAddr)
 }
 
 func validateProviderFields(provider string,
@@ -62,6 +69,7 @@ func validateProviderFields(provider string,
 	gcpJSON string,
 	azTenant, azClient, azSecret, azSub string,
 	osAuth, osUser, osPass, osProject string,
+	bmcUser, bmcPass, bmcAddr string,
 ) error {
 	switch provider {
 	case ProviderAWS:
@@ -107,6 +115,16 @@ func validateProviderFields(provider string,
 		if osProject == "" {
 			return fmt.Errorf("osProjectName is required for OpenStack provider")
 		}
+	case ProviderBaremetal:
+		if bmcUser == "" {
+			return fmt.Errorf("bmcUser is required for Baremetal provider")
+		}
+		if bmcPass == "" {
+			return fmt.Errorf("bmcPassword is required for Baremetal provider")
+		}
+		if bmcAddr == "" {
+			return fmt.Errorf("bmcAddr is required for Baremetal provider")
+		}
 	}
 	return nil
 }
@@ -119,6 +137,7 @@ func validateProviderFieldsForUpdate(provider string,
 	gcpJSON string,
 	azTenant, azClient, azSecret, azSub string,
 	osAuth, osUser, osPass, osProject string,
+	bmcUser, bmcPass, bmcAddr string,
 ) error {
 	if provider == ProviderGCP && gcpJSON != "" {
 		if err := validateGCPServiceAccountJSON(gcpJSON); err != nil {

--- a/pkg/cloudcreds/validate.go
+++ b/pkg/cloudcreds/validate.go
@@ -30,6 +30,8 @@ var reservedNames = map[string]bool{
 	"azure":     true,
 	"openstack": true,
 	"baremetal": true,
+	"vmware":    true,
+	"ibmcloud":  true,
 }
 
 // ValidateCreateRequest validates a CreateCloudCredentialRequest
@@ -51,7 +53,9 @@ func ValidateCreateRequest(req *CreateCloudCredentialRequest) error {
 		req.GCPServiceAccountJSON,
 		req.AzureTenantID, req.AzureClientID, req.AzureClientSecret, req.AzureSubscriptionID,
 		req.OSAuthURL, req.OSUsername, req.OSPassword, req.OSProjectName,
-		req.BMCUser, req.BMCPassword, req.BMCAddr)
+		req.BMCUser, req.BMCPassword, req.BMCAddr,
+		req.VSphereIP, req.VSphereUsername, req.VSpherePassword,
+		req.IBMCURL, req.IBMCAPIKey)
 }
 
 // ValidateUpdateRequest validates an UpdateCloudCredentialRequest against the existing provider
@@ -61,7 +65,9 @@ func ValidateUpdateRequest(req *UpdateCloudCredentialRequest, existingProvider s
 		req.GCPServiceAccountJSON,
 		req.AzureTenantID, req.AzureClientID, req.AzureClientSecret, req.AzureSubscriptionID,
 		req.OSAuthURL, req.OSUsername, req.OSPassword, req.OSProjectName,
-		req.BMCUser, req.BMCPassword, req.BMCAddr)
+		req.BMCUser, req.BMCPassword, req.BMCAddr,
+		req.VSphereIP, req.VSphereUsername, req.VSpherePassword,
+		req.IBMCURL, req.IBMCAPIKey)
 }
 
 func validateProviderFields(provider string,
@@ -70,6 +76,8 @@ func validateProviderFields(provider string,
 	azTenant, azClient, azSecret, azSub string,
 	osAuth, osUser, osPass, osProject string,
 	bmcUser, bmcPass, bmcAddr string,
+	vsphereIP, vsphereUser, vspherePass string,
+	ibmcURL, ibmcAPIKey string,
 ) error {
 	switch provider {
 	case ProviderAWS:
@@ -125,6 +133,23 @@ func validateProviderFields(provider string,
 		if bmcAddr == "" {
 			return fmt.Errorf("bmcAddr is required for Baremetal provider")
 		}
+	case ProviderVMware:
+		if vsphereIP == "" {
+			return fmt.Errorf("vsphereIp is required for VMware provider")
+		}
+		if vsphereUser == "" {
+			return fmt.Errorf("vsphereUsername is required for VMware provider")
+		}
+		if vspherePass == "" {
+			return fmt.Errorf("vspherePassword is required for VMware provider")
+		}
+	case ProviderIBMCloud:
+		if ibmcURL == "" {
+			return fmt.Errorf("ibmcUrl is required for IBM Cloud provider")
+		}
+		if ibmcAPIKey == "" {
+			return fmt.Errorf("ibmcApikey is required for IBM Cloud provider")
+		}
 	}
 	return nil
 }
@@ -138,6 +163,8 @@ func validateProviderFieldsForUpdate(provider string,
 	azTenant, azClient, azSecret, azSub string,
 	osAuth, osUser, osPass, osProject string,
 	bmcUser, bmcPass, bmcAddr string,
+	vsphereIP, vsphereUser, vspherePass string,
+	ibmcURL, ibmcAPIKey string,
 ) error {
 	if provider == ProviderGCP && gcpJSON != "" {
 		if err := validateGCPServiceAccountJSON(gcpJSON); err != nil {

--- a/pkg/cloudcreds/validate.go
+++ b/pkg/cloudcreds/validate.go
@@ -46,7 +46,7 @@ func ValidateCreateRequest(req *CreateCloudCredentialRequest) error {
 		return fmt.Errorf("provider is required")
 	}
 	if !ValidProviders[req.Provider] {
-		return fmt.Errorf("provider must be one of: aws, gcp, azure, openstack")
+		return fmt.Errorf("provider must be one of: aws, gcp, azure, openstack, baremetal, vmware, ibmcloud")
 	}
 
 	return validateProviderFields(req.Provider, req.AWSAccessKeyID, req.AWSSecretAccessKey, req.AWSDefaultRegion,

--- a/pkg/cloudcreds/validate_test.go
+++ b/pkg/cloudcreds/validate_test.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudcreds
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+func TestValidateCreateRequest(t *testing.T) {
+	validGCPJSON := base64.StdEncoding.EncodeToString([]byte(`{"type":"service_account","project_id":"my-project"}`))
+
+	tests := []struct {
+		name    string
+		req     CreateCloudCredentialRequest
+		wantErr string
+	}{
+		{
+			name:    "missing name",
+			req:     CreateCloudCredentialRequest{Provider: ProviderAWS},
+			wantErr: "name is required",
+		},
+		{
+			name:    "reserved name 'available'",
+			req:     CreateCloudCredentialRequest{Name: "available", Provider: ProviderAWS},
+			wantErr: "reserved",
+		},
+		{
+			name:    "missing provider",
+			req:     CreateCloudCredentialRequest{Name: "test"},
+			wantErr: "provider is required",
+		},
+		{
+			name:    "invalid provider",
+			req:     CreateCloudCredentialRequest{Name: "test", Provider: "oracle"},
+			wantErr: "provider must be one of",
+		},
+		// AWS
+		{
+			name:    "aws missing access key id",
+			req:     CreateCloudCredentialRequest{Name: "test", Provider: ProviderAWS, AWSSecretAccessKey: "s", AWSDefaultRegion: "r"},
+			wantErr: "awsAccessKeyId is required",
+		},
+		{
+			name:    "aws missing secret access key",
+			req:     CreateCloudCredentialRequest{Name: "test", Provider: ProviderAWS, AWSAccessKeyID: "k", AWSDefaultRegion: "r"},
+			wantErr: "awsSecretAccessKey is required",
+		},
+		{
+			name:    "aws missing region",
+			req:     CreateCloudCredentialRequest{Name: "test", Provider: ProviderAWS, AWSAccessKeyID: "k", AWSSecretAccessKey: "s"},
+			wantErr: "awsDefaultRegion is required",
+		},
+		{
+			name: "aws valid",
+			req:  CreateCloudCredentialRequest{Name: "test", Provider: ProviderAWS, AWSAccessKeyID: "AKIAIOSFODNN7EXAMPLE", AWSSecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", AWSDefaultRegion: "us-east-1"},
+		},
+		// GCP
+		{
+			name:    "gcp missing service account json",
+			req:     CreateCloudCredentialRequest{Name: "test", Provider: ProviderGCP},
+			wantErr: "gcpServiceAccountJson is required",
+		},
+		{
+			name:    "gcp invalid base64",
+			req:     CreateCloudCredentialRequest{Name: "test", Provider: ProviderGCP, GCPServiceAccountJSON: "not-base64!!!"},
+			wantErr: "valid base64",
+		},
+		{
+			name:    "gcp invalid json",
+			req:     CreateCloudCredentialRequest{Name: "test", Provider: ProviderGCP, GCPServiceAccountJSON: base64.StdEncoding.EncodeToString([]byte("not json"))},
+			wantErr: "valid JSON",
+		},
+		{
+			name:    "gcp missing type field",
+			req:     CreateCloudCredentialRequest{Name: "test", Provider: ProviderGCP, GCPServiceAccountJSON: base64.StdEncoding.EncodeToString([]byte(`{"project_id":"p"}`))},
+			wantErr: "missing required field 'type'",
+		},
+		{
+			name:    "gcp missing project_id field",
+			req:     CreateCloudCredentialRequest{Name: "test", Provider: ProviderGCP, GCPServiceAccountJSON: base64.StdEncoding.EncodeToString([]byte(`{"type":"service_account"}`))},
+			wantErr: "missing required field 'project_id'",
+		},
+		{
+			name: "gcp valid",
+			req:  CreateCloudCredentialRequest{Name: "test", Provider: ProviderGCP, GCPServiceAccountJSON: validGCPJSON},
+		},
+		// Azure
+		{
+			name:    "azure missing tenant id",
+			req:     CreateCloudCredentialRequest{Name: "test", Provider: ProviderAzure, AzureClientID: "c", AzureClientSecret: "s", AzureSubscriptionID: "sub"},
+			wantErr: "azureTenantId is required",
+		},
+		{
+			name:    "azure missing client id",
+			req:     CreateCloudCredentialRequest{Name: "test", Provider: ProviderAzure, AzureTenantID: "t", AzureClientSecret: "s", AzureSubscriptionID: "sub"},
+			wantErr: "azureClientId is required",
+		},
+		{
+			name:    "azure missing client secret",
+			req:     CreateCloudCredentialRequest{Name: "test", Provider: ProviderAzure, AzureTenantID: "t", AzureClientID: "c", AzureSubscriptionID: "sub"},
+			wantErr: "azureClientSecret is required",
+		},
+		{
+			name:    "azure missing subscription id",
+			req:     CreateCloudCredentialRequest{Name: "test", Provider: ProviderAzure, AzureTenantID: "t", AzureClientID: "c", AzureClientSecret: "s"},
+			wantErr: "azureSubscriptionId is required",
+		},
+		{
+			name: "azure valid",
+			req:  CreateCloudCredentialRequest{Name: "test", Provider: ProviderAzure, AzureTenantID: "t", AzureClientID: "c", AzureClientSecret: "s", AzureSubscriptionID: "sub"},
+		},
+		// OpenStack
+		{
+			name:    "openstack missing auth url",
+			req:     CreateCloudCredentialRequest{Name: "test", Provider: ProviderOpenStack, OSUsername: "u", OSPassword: "p", OSProjectName: "proj"},
+			wantErr: "osAuthUrl is required",
+		},
+		{
+			name:    "openstack missing username",
+			req:     CreateCloudCredentialRequest{Name: "test", Provider: ProviderOpenStack, OSAuthURL: "http://auth", OSPassword: "p", OSProjectName: "proj"},
+			wantErr: "osUsername is required",
+		},
+		{
+			name:    "openstack missing password",
+			req:     CreateCloudCredentialRequest{Name: "test", Provider: ProviderOpenStack, OSAuthURL: "http://auth", OSUsername: "u", OSProjectName: "proj"},
+			wantErr: "osPassword is required",
+		},
+		{
+			name:    "openstack missing project name",
+			req:     CreateCloudCredentialRequest{Name: "test", Provider: ProviderOpenStack, OSAuthURL: "http://auth", OSUsername: "u", OSPassword: "p"},
+			wantErr: "osProjectName is required",
+		},
+		{
+			name: "openstack valid",
+			req:  CreateCloudCredentialRequest{Name: "test", Provider: ProviderOpenStack, OSAuthURL: "http://auth:5000/v3", OSUsername: "admin", OSPassword: "secret", OSProjectName: "myproject"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateCreateRequest(&tt.req)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Errorf("expected error containing %q, got nil", tt.wantErr)
+				return
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateUpdateRequest(t *testing.T) {
+	tests := []struct {
+		name             string
+		req              UpdateCloudCredentialRequest
+		existingProvider string
+		wantErr          string
+	}{
+		{
+			name:             "gcp invalid json on update",
+			req:              UpdateCloudCredentialRequest{GCPServiceAccountJSON: base64.StdEncoding.EncodeToString([]byte("not json"))},
+			existingProvider: ProviderGCP,
+			wantErr:          "valid JSON",
+		},
+		{
+			name:             "gcp empty json on update is ok (keep existing)",
+			req:              UpdateCloudCredentialRequest{},
+			existingProvider: ProviderGCP,
+		},
+		{
+			name:             "aws update with partial fields is ok",
+			req:              UpdateCloudCredentialRequest{AWSDefaultRegion: "eu-west-1"},
+			existingProvider: ProviderAWS,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateUpdateRequest(&tt.req, tt.existingProvider)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Errorf("expected error containing %q, got nil", tt.wantErr)
+				return
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/cloudcreds/validate_test.go
+++ b/pkg/cloudcreds/validate_test.go
@@ -150,6 +150,32 @@ func TestValidateCreateRequest(t *testing.T) {
 			name: "openstack valid",
 			req:  CreateCloudCredentialRequest{Name: "test", Provider: ProviderOpenStack, OSAuthURL: "http://auth:5000/v3", OSUsername: "admin", OSPassword: "secret", OSProjectName: "myproject"},
 		},
+		// Baremetal
+		{
+			name:    "baremetal missing bmc user",
+			req:     CreateCloudCredentialRequest{Name: "test", Provider: ProviderBaremetal, BMCPassword: "p", BMCAddr: "192.168.1.100"},
+			wantErr: "bmcUser is required",
+		},
+		{
+			name:    "baremetal missing bmc password",
+			req:     CreateCloudCredentialRequest{Name: "test", Provider: ProviderBaremetal, BMCUser: "admin", BMCAddr: "192.168.1.100"},
+			wantErr: "bmcPassword is required",
+		},
+		{
+			name:    "baremetal missing bmc addr",
+			req:     CreateCloudCredentialRequest{Name: "test", Provider: ProviderBaremetal, BMCUser: "admin", BMCPassword: "p"},
+			wantErr: "bmcAddr is required",
+		},
+		{
+			name: "baremetal valid",
+			req:  CreateCloudCredentialRequest{Name: "test", Provider: ProviderBaremetal, BMCUser: "admin", BMCPassword: "secret", BMCAddr: "192.168.1.100"},
+		},
+		// Reserved names
+		{
+			name:    "reserved name 'baremetal'",
+			req:     CreateCloudCredentialRequest{Name: "baremetal", Provider: ProviderBaremetal, BMCUser: "u", BMCPassword: "p", BMCAddr: "a"},
+			wantErr: "reserved",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cloudcreds/validate_test.go
+++ b/pkg/cloudcreds/validate_test.go
@@ -170,6 +170,41 @@ func TestValidateCreateRequest(t *testing.T) {
 			name: "baremetal valid",
 			req:  CreateCloudCredentialRequest{Name: "test", Provider: ProviderBaremetal, BMCUser: "admin", BMCPassword: "secret", BMCAddr: "192.168.1.100"},
 		},
+		// VMware
+		{
+			name:    "vmware missing vsphere ip",
+			req:     CreateCloudCredentialRequest{Name: "test", Provider: ProviderVMware, VSphereUsername: "u", VSpherePassword: "p"},
+			wantErr: "vsphereIp is required",
+		},
+		{
+			name:    "vmware missing vsphere username",
+			req:     CreateCloudCredentialRequest{Name: "test", Provider: ProviderVMware, VSphereIP: "10.0.0.1", VSpherePassword: "p"},
+			wantErr: "vsphereUsername is required",
+		},
+		{
+			name:    "vmware missing vsphere password",
+			req:     CreateCloudCredentialRequest{Name: "test", Provider: ProviderVMware, VSphereIP: "10.0.0.1", VSphereUsername: "u"},
+			wantErr: "vspherePassword is required",
+		},
+		{
+			name: "vmware valid",
+			req:  CreateCloudCredentialRequest{Name: "test", Provider: ProviderVMware, VSphereIP: "10.0.0.1", VSphereUsername: "admin@vsphere.local", VSpherePassword: "secret"},
+		},
+		// IBM Cloud
+		{
+			name:    "ibmcloud missing url",
+			req:     CreateCloudCredentialRequest{Name: "test", Provider: ProviderIBMCloud, IBMCAPIKey: "key"},
+			wantErr: "ibmcUrl is required",
+		},
+		{
+			name:    "ibmcloud missing apikey",
+			req:     CreateCloudCredentialRequest{Name: "test", Provider: ProviderIBMCloud, IBMCURL: "https://us-south.iaas.cloud.ibm.com/v1"},
+			wantErr: "ibmcApikey is required",
+		},
+		{
+			name: "ibmcloud valid",
+			req:  CreateCloudCredentialRequest{Name: "test", Provider: ProviderIBMCloud, IBMCURL: "https://us-south.iaas.cloud.ibm.com/v1", IBMCAPIKey: "my-api-key"},
+		},
 		// Reserved names
 		{
 			name:    "reserved name 'baremetal'",


### PR DESCRIPTION
## Summary

- Adds first-class cloud credential management for AWS, GCP, Azure, and OpenStack providers
- Credentials stored as Opaque K8s Secrets with labeled metadata and group-based access control
- Injected into scenario pods via `SecretKeyRef` env vars and `SecretVolumeSource` file mounts — credentials never appear as plaintext in CRD specs or pod specs
- Graph runs support graph-level default + per-node credential override for multi-cloud scenarios

## Changes

### New package: `pkg/cloudcreds/`
- `types.go` — Provider constants, Secret data keys, request/response types
- `labels.go` — Label/annotation builders with group-based access (follows `pkg/registry/labels.go` pattern)
- `validate.go` — Per-provider field validation, reserved name guard ("available"), provider immutability on update
- `injection.go` — `InjectCredentials()` returns `SecretKeyRef` env vars + `SecretVolumeSource` volumes per provider

### New CRUD API: `/api/v1/cloud-credentials`
- `POST` — Create (admin only)
- `GET` — List all (admin only)
- `GET /{name}` — Get by name (admin only)
- `PUT /{name}` — Update (admin only, provider immutable)
- `DELETE /{name}` — Delete (admin only)
- `GET /available` — List accessible to current user (group-based access)

### CRD changes
- `CloudCredentialRef` added to `KrknScenarioRunSpec`, `KrknGraphRunSpec`, and `GraphScenarioNode`

### Controller integration
- `prepareJobResources()` injects credentials via `SecretKeyRef` when `CloudCredentialRef` is set
- `createScenarioRun()` propagates credential ref from graph → node with per-node override
- Generic `overrideRef()` helper for future graph-level ref propagation (registries, etc.)

### API handler integration
- `PostScenarioRun()` validates credential access + sets ref on CRD spec
- `CreateGraphRun()` validates graph-level + per-node credential refs

## Security
- Credentials stored in Opaque K8s Secrets, never in ConfigMaps
- API responses never include Secret data
- CRD spec stores only the Secret name (not values)
- Pod spec uses `SecretKeyRef` — Kubernetes resolves values at pod start, never plaintext
- GCP service account JSON mounted via `SecretVolumeSource` (read-only)

## Test plan
- [x] 45 unit tests for `pkg/cloudcreds/` (labels, validation, injection) — all passing with `-race`
- [x] `make build` — clean
- [x] `make generate && make manifests` — CRD YAMLs updated
- [ ] Integration: Create credential via API → run scenario → verify pod has SecretKeyRef env vars
- [ ] Security: Verify `kubectl get ksr -o yaml` shows only ref name, not credential values

Closes: #43
Jira: CHAOS-1708

🤖 Generated with [Claude Code](https://claude.com/claude-code)