### PR TITLE
fix(security): add API middleware protections and error response consistency

### DIFF
--- a/internal/api/authorization.go
+++ b/internal/api/authorization.go
@@ -125,7 +125,10 @@ func (h *Handler) checkScenarioRunAccessWithAction(
 
 	// Defensive check - should never happen with RequireAuth middleware
 	if claims == nil {
-		http.Error(w, `{"error":"unauthorized","message":"No authentication claims found"}`, http.StatusUnauthorized)
+		writeJSONError(w, http.StatusUnauthorized, ErrorResponse{
+			Error:   "unauthorized",
+			Message: "No authentication claims found",
+		})
 		return false
 	}
 
@@ -136,7 +139,10 @@ func (h *Handler) checkScenarioRunAccessWithAction(
 
 	// Reject runs without jobs (defensive - should not happen for new runs)
 	if len(scenarioRun.Status.ClusterJobs) == 0 {
-		http.Error(w, `{"error":"forbidden","message":"Access denied. This scenario run has no jobs"}`, http.StatusForbidden)
+		writeJSONError(w, http.StatusForbidden, ErrorResponse{
+			Error:   "forbidden",
+			Message: "Access denied. This scenario run has no jobs",
+		})
 		return false
 	}
 
@@ -152,13 +158,18 @@ func (h *Handler) checkScenarioRunAccessWithAction(
 		log.FromContext(ctx).Error(err, "Failed to check scenario run access",
 			"userID", claims.UserID,
 			"action", requiredAction)
-		http.Error(w, `{"error":"internal_error","message":"Failed to validate access"}`, http.StatusInternalServerError)
+		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
+			Error:   "internal_error",
+			Message: "Failed to validate access",
+		})
 		return false
 	}
 
 	if !hasAccess {
-		errorMsg := fmt.Sprintf(`{"error":"forbidden","message":"Access denied. You do not have permission to %s this scenario run"}`, actionName)
-		http.Error(w, errorMsg, http.StatusForbidden)
+		writeJSONError(w, http.StatusForbidden, ErrorResponse{
+			Error:   "forbidden",
+			Message: fmt.Sprintf("Access denied. You do not have permission to %s this scenario run", actionName),
+		})
 		return false
 	}
 
@@ -351,7 +362,10 @@ func (h *Handler) checkJobAccess(
 
 	// Defensive check
 	if claims == nil {
-		http.Error(w, `{"error":"unauthorized","message":"No authentication claims found"}`, http.StatusUnauthorized)
+		writeJSONError(w, http.StatusUnauthorized, ErrorResponse{
+			Error:   "unauthorized",
+			Message: "No authentication claims found",
+		})
 		return false
 	}
 
@@ -362,7 +376,10 @@ func (h *Handler) checkJobAccess(
 
 	// Check if job has ClusterAPIURL
 	if job.ClusterAPIURL == "" {
-		http.Error(w, `{"error":"forbidden","message":"Access denied. Job has no cluster API URL"}`, http.StatusForbidden)
+		writeJSONError(w, http.StatusForbidden, ErrorResponse{
+			Error:   "forbidden",
+			Message: "Access denied. Job has no cluster API URL",
+		})
 		return false
 	}
 
@@ -381,13 +398,18 @@ func (h *Handler) checkJobAccess(
 			"userID", claims.UserID,
 			"jobID", job.JobID,
 			"action", requiredAction)
-		http.Error(w, `{"error":"internal_error","message":"Failed to validate access"}`, http.StatusInternalServerError)
+		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
+			Error:   "internal_error",
+			Message: "Failed to validate access",
+		})
 		return false
 	}
 
 	if !hasAccess {
-		errorMsg := fmt.Sprintf(`{"error":"forbidden","message":"Access denied. You do not have permission to %s this job"}`, actionName)
-		http.Error(w, errorMsg, http.StatusForbidden)
+		writeJSONError(w, http.StatusForbidden, ErrorResponse{
+			Error:   "forbidden",
+			Message: fmt.Sprintf("Access denied. You do not have permission to %s this job", actionName),
+		})
 		return false
 	}
 

--- a/internal/api/graphrun_handlers.go
+++ b/internal/api/graphrun_handlers.go
@@ -700,7 +700,10 @@ func (h *Handler) GraphRunsRouter(w http.ResponseWriter, r *http.Request) {
 		case http.MethodPost:
 			h.CreateGraphRun(w, r)
 		default:
-			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			writeJSONError(w, http.StatusMethodNotAllowed, ErrorResponse{
+				Error:   "method_not_allowed",
+				Message: "Method not allowed",
+			})
 		}
 		return
 	}
@@ -713,12 +716,18 @@ func (h *Handler) GraphRunsRouter(w http.ResponseWriter, r *http.Request) {
 		case http.MethodDelete:
 			h.DeleteGraphRun(w, r)
 		default:
-			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			writeJSONError(w, http.StatusMethodNotAllowed, ErrorResponse{
+				Error:   "method_not_allowed",
+				Message: "Method not allowed",
+			})
 		}
 		return
 	}
 
-	http.Error(w, "Not found", http.StatusNotFound)
+	writeJSONError(w, http.StatusNotFound, ErrorResponse{
+		Error:   "not_found",
+		Message: "Not found",
+	})
 }
 
 // parseBoolHeader parses a header value as a boolean, accepting common representations.

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -398,7 +398,10 @@ func (h *Handler) GetTargetByUUID(w http.ResponseWriter, r *http.Request) {
 		Namespace: h.namespace,
 	}, &targetRequest); err != nil {
 		if client.IgnoreNotFound(err) == nil {
-			w.WriteHeader(http.StatusNotFound)
+			writeJSONError(w, http.StatusNotFound, ErrorResponse{
+				Error:   "not_found",
+				Message: "Target not found",
+			})
 		} else {
 			log.FromContext(ctx).Error(err, "Failed to fetch KrknTargetRequest", "uuid", uuid)
 			writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
@@ -628,7 +631,10 @@ func convertInputFields(fields []typing.InputField) []InputFieldResponse {
 func writeJSON(w http.ResponseWriter, status int, data interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(data) // If encoding fails, client gets partial response
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		logger := log.Log.WithName("api")
+		logger.Error(err, "Failed to encode JSON response")
+	}
 }
 
 // writeJSONError writes a JSON error response with the given status code
@@ -2641,7 +2647,10 @@ func (h *Handler) ScenariosRunRouter(w http.ResponseWriter, r *http.Request) {
 		case http.MethodGet:
 			h.ListScenarioRuns(w, r)
 		default:
-			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			writeJSONError(w, http.StatusMethodNotAllowed, ErrorResponse{
+				Error:   "method_not_allowed",
+				Message: "Method not allowed",
+			})
 		}
 		return
 	}
@@ -2656,7 +2665,10 @@ func (h *Handler) ScenariosRunRouter(w http.ResponseWriter, r *http.Request) {
 			if r.Method == http.MethodGet {
 				h.GetScenarioReplay(w, r)
 			} else {
-				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+				writeJSONError(w, http.StatusMethodNotAllowed, ErrorResponse{
+					Error:   "method_not_allowed",
+					Message: "Method not allowed",
+				})
 			}
 			return
 		}
@@ -2669,7 +2681,10 @@ func (h *Handler) ScenariosRunRouter(w http.ResponseWriter, r *http.Request) {
 			case http.MethodDelete:
 				h.DeleteSingleJob(w, r)
 			default:
-				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+				writeJSONError(w, http.StatusMethodNotAllowed, ErrorResponse{
+					Error:   "method_not_allowed",
+					Message: "Method not allowed",
+				})
 			}
 			return
 		}
@@ -2681,12 +2696,18 @@ func (h *Handler) ScenariosRunRouter(w http.ResponseWriter, r *http.Request) {
 		case http.MethodDelete:
 			h.DeleteScenarioRunComplete(w, r)
 		default:
-			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			writeJSONError(w, http.StatusMethodNotAllowed, ErrorResponse{
+				Error:   "method_not_allowed",
+				Message: "Method not allowed",
+			})
 		}
 		return
 	}
 
-	http.Error(w, "Not found", http.StatusNotFound)
+	writeJSONError(w, http.StatusNotFound, ErrorResponse{
+		Error:   "not_found",
+		Message: "Not found",
+	})
 }
 
 // convertMetaTime converts metav1.Time to *time.Time

--- a/internal/api/providers_handlers.go
+++ b/internal/api/providers_handlers.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	krknv1alpha1 "github.com/krkn-chaos/krkn-operator/api/v1alpha1"
@@ -38,9 +39,9 @@ func (h *Handler) ListProviders(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	logger := log.FromContext(ctx)
 
-	// List all KrknOperatorTargetProvider CRs
+	// List all KrknOperatorTargetProvider CRs in the operator namespace
 	var providerList krknv1alpha1.KrknOperatorTargetProviderList
-	if err := h.client.List(ctx, &providerList); err != nil {
+	if err := h.client.List(ctx, &providerList, client.InNamespace(h.namespace)); err != nil {
 		logger.Error(err, "Failed to list KrknOperatorTargetProvider CRs")
 		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
 			Error:   "internal_error",
@@ -94,9 +95,9 @@ func (h *Handler) UpdateProviderStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Find provider by name (iterate through all providers in all namespaces)
+	// Find provider by name in the operator namespace
 	var providerList krknv1alpha1.KrknOperatorTargetProviderList
-	if err := h.client.List(ctx, &providerList); err != nil {
+	if err := h.client.List(ctx, &providerList, client.InNamespace(h.namespace)); err != nil {
 		logger.Error(err, "Failed to list providers")
 		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
 			Error:   "internal_error",

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -255,10 +255,12 @@ func NewServer(port int, client client.Client, clientset kubernetes.Interface, n
 		http.NotFound(w, r)
 	})
 
-	// Wrap mux with logging middleware
+	// Wrap mux with middleware chain: logging -> body size limit -> routes
+	// maxBodySize is 10MB, applied only to POST/PUT/PATCH requests
+	const maxBodySize int64 = 10 << 20 // 10 MB
 	server := &http.Server{
 		Addr:              fmt.Sprintf(":%d", port),
-		Handler:           loggingMiddleware(mux),
+		Handler:           loggingMiddleware(maxBodySizeMiddleware(maxBodySize)(mux)),
 		ReadHeaderTimeout: 30 * time.Second,  // Prevent Slowloris attacks
 		ReadTimeout:       60 * time.Second,  // Total request read timeout
 		WriteTimeout:      60 * time.Second,  // Response write timeout
@@ -328,6 +330,21 @@ func (s *Server) Shutdown() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	return s.server.Shutdown(ctx)
+}
+
+// maxBodySizeMiddleware returns middleware that limits request body size for
+// POST, PUT, and PATCH methods using http.MaxBytesReader. This prevents
+// clients from sending excessively large payloads that could exhaust memory.
+// GET, DELETE, and other methods are passed through without modification.
+func maxBodySizeMiddleware(maxBytes int64) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost || r.Method == http.MethodPut || r.Method == http.MethodPatch {
+				r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
 }
 
 // loggingMiddleware is a logging middleware for HTTP requests

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -19,10 +19,118 @@ Assisted-by: Claude Sonnet 4.5 (claude-sonnet-4-5@20250929)
 package api
 
 import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	_ "github.com/krkn-chaos/krkn-operator/api/v1alpha1"
 )
+
+// TestMaxBodySizeMiddleware verifies that the maxBodySizeMiddleware correctly
+// limits request body size for POST/PUT/PATCH methods and passes through
+// GET/DELETE requests without modification.
+func TestMaxBodySizeMiddleware(t *testing.T) {
+	const maxBytes int64 = 1024 // 1 KB limit for testing
+
+	// echoHandler reads the full body and echoes it back.
+	// If reading fails (body too large), it returns 413.
+	echoHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			// MaxBytesReader returns an error when body exceeds limit
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	})
+
+	handler := maxBodySizeMiddleware(maxBytes)(echoHandler)
+
+	tests := []struct {
+		name           string
+		method         string
+		bodySize       int
+		expectedStatus int
+	}{
+		{
+			name:           "POST within limit",
+			method:         http.MethodPost,
+			bodySize:       512,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "POST exceeds limit",
+			method:         http.MethodPost,
+			bodySize:       2048,
+			expectedStatus: http.StatusRequestEntityTooLarge,
+		},
+		{
+			name:           "PUT within limit",
+			method:         http.MethodPut,
+			bodySize:       512,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "PUT exceeds limit",
+			method:         http.MethodPut,
+			bodySize:       2048,
+			expectedStatus: http.StatusRequestEntityTooLarge,
+		},
+		{
+			name:           "PATCH within limit",
+			method:         http.MethodPatch,
+			bodySize:       512,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "PATCH exceeds limit",
+			method:         http.MethodPatch,
+			bodySize:       2048,
+			expectedStatus: http.StatusRequestEntityTooLarge,
+		},
+		{
+			name:           "GET not limited",
+			method:         http.MethodGet,
+			bodySize:       2048,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "DELETE not limited",
+			method:         http.MethodDelete,
+			bodySize:       2048,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "POST at exact limit",
+			method:         http.MethodPost,
+			bodySize:       1024,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "POST one byte over limit",
+			method:         http.MethodPost,
+			bodySize:       1025,
+			expectedStatus: http.StatusRequestEntityTooLarge,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := strings.NewReader(strings.Repeat("x", tt.bodySize))
+			req := httptest.NewRequest(tt.method, "/test", body)
+			w := httptest.NewRecorder()
+
+			handler.ServeHTTP(w, req)
+
+			if w.Code != tt.expectedStatus {
+				t.Errorf("expected status %d, got %d", tt.expectedStatus, w.Code)
+			}
+		})
+	}
+}
 
 // TestWorkflowsAvailableMethodGuard is a compile-time check that ensures
 // the method guard exists in server.go for /workflows/available endpoint.


### PR DESCRIPTION
## Summary

- Add `maxBodySizeMiddleware` (10MB limit) for POST/PUT/PATCH requests to prevent memory exhaustion from oversized payloads
- Replace all `http.Error()` calls in authorization.go, handlers.go (ScenariosRunRouter), and graphrun_handlers.go (GraphRunsRouter) with `writeJSONError()` for consistent JSON error responses with proper Content-Type headers
- Fix empty 404 response in `GetTargetByUUID` -- now returns a JSON error body
- Fix silent error discard in `writeJSON` -- encoding errors are now logged
- Scope `ListProviders` and `UpdateProviderStatus` queries to operator namespace via `client.InNamespace(h.namespace)`

## Test plan

- [x] Added table-driven unit tests for `maxBodySizeMiddleware` covering:
  - POST/PUT/PATCH body size enforcement (within limit, exceeds limit, exact limit, one byte over)
  - GET/DELETE passthrough (no size restriction)
- [x] All existing API tests pass (`go test ./internal/api/...`)
- [x] `go build ./...` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)