### PR TITLE
fix(security): fix context propagation and error information leakage

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1094,9 +1094,10 @@ func (h *Handler) PostScenarioRun(w http.ResponseWriter, r *http.Request) {
 	// Parse request body
 	var req ScenarioRunRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		logger.Error(err, "Failed to decode scenario run request body")
 		writeJSONError(w, http.StatusBadRequest, ErrorResponse{
 			Error:   "bad_request",
-			Message: "Invalid request body: " + err.Error(),
+			Message: "Invalid request body",
 		})
 		return
 	}
@@ -2000,7 +2001,7 @@ func (h *Handler) GetScenarioRunLogs(w http.ResponseWriter, r *http.Request) {
 			_ = conn.WriteMessage(websocket.TextMessage, []byte("ERROR: Pod no longer exists — logs may have been cleaned up")) // Best-effort error reporting
 		} else {
 			logger.Error(err, "Failed to get pod", "jobID", jobID, "podName", targetJob.PodName)
-			_ = conn.WriteMessage(websocket.TextMessage, []byte(fmt.Sprintf("ERROR: Failed to get pod: %s", err.Error()))) // Best-effort error reporting
+			_ = conn.WriteMessage(websocket.TextMessage, []byte("ERROR: Failed to get pod")) // Best-effort error reporting
 		}
 		return
 	}
@@ -2043,7 +2044,7 @@ func (h *Handler) GetScenarioRunLogs(w http.ResponseWriter, r *http.Request) {
 			"jobID", jobID,
 			"podName", pod.Name,
 			"namespace", h.namespace)
-		_ = conn.WriteMessage(websocket.TextMessage, []byte(fmt.Sprintf("ERROR: Failed to open log stream: %s", err.Error()))) // Best-effort error reporting
+		_ = conn.WriteMessage(websocket.TextMessage, []byte("ERROR: Failed to open log stream")) // Best-effort error reporting
 		return
 	}
 	defer stream.Close()
@@ -2083,7 +2084,7 @@ func (h *Handler) GetScenarioRunLogs(w http.ResponseWriter, r *http.Request) {
 			"jobID", jobID,
 			"podName", pod.Name,
 			"linesStreamed", lineCount)
-		_ = conn.WriteMessage(websocket.TextMessage, []byte(fmt.Sprintf("ERROR: Log stream error: %s", err.Error()))) // Best-effort error reporting
+		_ = conn.WriteMessage(websocket.TextMessage, []byte("ERROR: Log stream error")) // Best-effort error reporting
 		return
 	}
 

--- a/internal/api/provider_config_handlers.go
+++ b/internal/api/provider_config_handlers.go
@@ -22,7 +22,6 @@ package api
 // +kubebuilder:rbac:groups=krkn.krkn-chaos.dev,resources=krknoperatortargetproviderconfigs/status,verbs=get
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -43,31 +42,38 @@ import (
 // PostProviderConfig handles POST /api/v1/provider-config endpoint
 // Creates a new KrknOperatorTargetProviderConfig CR and returns the UUID
 func (h *Handler) PostProviderConfig(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	logger := log.FromContext(ctx)
+
 	// Use common function to create provider config request
 	uuid, err := provider.CreateProviderConfigRequest(
-		context.Background(),
+		ctx,
 		h.client,
 		h.namespace,
 		"", // Let the function generate the name
 	)
 	if err != nil {
+		logger.Error(err, "Failed to create KrknOperatorTargetProviderConfig")
 		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
 			Error:   "internal_error",
-			Message: "Failed to create KrknOperatorTargetProviderConfig: " + err.Error(),
+			Message: "Failed to create KrknOperatorTargetProviderConfig",
 		})
 		return
 	}
 
-	// Return 102 Processing with the UUID
+	// Return 202 Accepted with the UUID
 	response := map[string]string{
 		"uuid": uuid,
 	}
-	writeJSON(w, http.StatusProcessing, response)
+	writeJSON(w, http.StatusAccepted, response)
 }
 
 // GetProviderConfigByUUID handles GET /api/v1/provider-config/{uuid} endpoint
 // Returns 100 Continue when pending, 200 OK with config_data when Completed
 func (h *Handler) GetProviderConfigByUUID(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	logger := log.FromContext(ctx)
+
 	uuid, err := extractPathSuffix(r.URL.Path, ProviderConfigPath+"/")
 	if err != nil {
 		writeJSONError(w, http.StatusBadRequest, ErrorResponse{
@@ -78,7 +84,7 @@ func (h *Handler) GetProviderConfigByUUID(w http.ResponseWriter, r *http.Request
 	}
 
 	var config krknv1alpha1.KrknOperatorTargetProviderConfig
-	if err := h.client.Get(context.Background(), types.NamespacedName{
+	if err := h.client.Get(ctx, types.NamespacedName{
 		Name:      uuid,
 		Namespace: h.namespace,
 	}, &config); err != nil {
@@ -88,9 +94,10 @@ func (h *Handler) GetProviderConfigByUUID(w http.ResponseWriter, r *http.Request
 				Message: "KrknOperatorTargetProviderConfig not found",
 			})
 		} else {
+			logger.Error(err, "Failed to fetch KrknOperatorTargetProviderConfig", "uuid", uuid)
 			writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
 				Error:   "internal_error",
-				Message: "Failed to fetch KrknOperatorTargetProviderConfig: " + err.Error(),
+				Message: "Failed to fetch KrknOperatorTargetProviderConfig",
 			})
 		}
 		return

--- a/internal/api/targets_crud.go
+++ b/internal/api/targets_crud.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	krknv1alpha1 "github.com/krkn-chaos/krkn-operator/api/v1alpha1"
 	"github.com/krkn-chaos/krkn-operator/internal/kubeconfig"
@@ -147,14 +148,16 @@ func generateKubeconfigFromCredentialsType(req CreateTargetRequest) (string, str
 // CreateTarget handles POST /api/v1/operator/targets
 // Creates a new KrknOperatorTarget CR with a generated UUID and associated Secret
 func (h *Handler) CreateTarget(w http.ResponseWriter, r *http.Request) {
-	ctx := context.Background()
+	ctx := r.Context()
+	logger := log.FromContext(ctx)
 
 	// Parse request body
 	var req CreateTargetRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		logger.Error(err, "Failed to decode create target request body")
 		writeJSONError(w, http.StatusBadRequest, ErrorResponse{
 			Error:   "bad_request",
-			Message: "Invalid request body: " + err.Error(),
+			Message: "Invalid request body",
 		})
 		return
 	}
@@ -187,9 +190,10 @@ func (h *Handler) CreateTarget(w http.ResponseWriter, r *http.Request) {
 	// Check for duplicate clusterName or clusterAPIURL
 	var existingTargets krknv1alpha1.KrknOperatorTargetList
 	if err := h.client.List(ctx, &existingTargets, client.InNamespace(h.namespace)); err != nil {
+		logger.Error(err, "Failed to check existing targets")
 		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
 			Error:   "internal_error",
-			Message: "Failed to check existing targets: " + err.Error(),
+			Message: "Failed to check existing targets",
 		})
 		return
 	}
@@ -219,9 +223,10 @@ func (h *Handler) CreateTarget(w http.ResponseWriter, r *http.Request) {
 	// Create Secret with kubeconfig
 	secretData, err := kubeconfig.MarshalSecretData(kubeconfigBase64)
 	if err != nil {
+		logger.Error(err, "Failed to marshal secret data")
 		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
 			Error:   "internal_error",
-			Message: "Failed to marshal secret data: " + err.Error(),
+			Message: "Failed to marshal secret data",
 		})
 		return
 	}
@@ -240,9 +245,10 @@ func (h *Handler) CreateTarget(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.client.Create(ctx, secret); err != nil {
+		logger.Error(err, "Failed to create secret")
 		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
 			Error:   "internal_error",
-			Message: "Failed to create secret: " + err.Error(),
+			Message: "Failed to create secret",
 		})
 		return
 	}
@@ -268,9 +274,10 @@ func (h *Handler) CreateTarget(w http.ResponseWriter, r *http.Request) {
 		// Cleanup secret on error
 		_ = h.client.Delete(ctx, secret) // Best-effort cleanup
 
+		logger.Error(err, "Failed to create target")
 		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
 			Error:   "internal_error",
-			Message: "Failed to create target: " + err.Error(),
+			Message: "Failed to create target",
 		})
 		return
 	}
@@ -285,9 +292,10 @@ func (h *Handler) CreateTarget(w http.ResponseWriter, r *http.Request) {
 		_ = h.client.Delete(ctx, target) // Best-effort cleanup
 		_ = h.client.Delete(ctx, secret) // Best-effort cleanup
 
+		logger.Error(err, "Failed to update target status")
 		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
 			Error:   "internal_error",
-			Message: "Failed to update target status: " + err.Error(),
+			Message: "Failed to update target status",
 		})
 		return
 	}
@@ -304,14 +312,16 @@ func (h *Handler) CreateTarget(w http.ResponseWriter, r *http.Request) {
 // ListTargets handles GET /api/v1/operator/targets
 // Returns a list of all KrknOperatorTarget CRs
 func (h *Handler) ListTargets(w http.ResponseWriter, r *http.Request) {
-	ctx := context.Background()
+	ctx := r.Context()
+	logger := log.FromContext(ctx)
 
 	// List all targets
 	var targets krknv1alpha1.KrknOperatorTargetList
 	if err := h.client.List(ctx, &targets, client.InNamespace(h.namespace)); err != nil {
+		logger.Error(err, "Failed to list targets")
 		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
 			Error:   "internal_error",
-			Message: "Failed to list targets: " + err.Error(),
+			Message: "Failed to list targets",
 		})
 		return
 	}
@@ -332,7 +342,7 @@ func (h *Handler) ListTargets(w http.ResponseWriter, r *http.Request) {
 // GetTarget handles GET /api/v1/operator/targets/{uuid}
 // Returns a single KrknOperatorTarget by UUID
 func (h *Handler) GetTarget(w http.ResponseWriter, r *http.Request) {
-	ctx := context.Background()
+	ctx := r.Context()
 
 	targetUUID, err := extractPathSuffix(r.URL.Path, OperatorTargetsPath+"/")
 	if err != nil {
@@ -356,7 +366,8 @@ func (h *Handler) GetTarget(w http.ResponseWriter, r *http.Request) {
 // UpdateTarget handles PUT /api/v1/operator/targets/{uuid}
 // Updates an existing KrknOperatorTarget (overwrites the Secret kubeconfig)
 func (h *Handler) UpdateTarget(w http.ResponseWriter, r *http.Request) {
-	ctx := context.Background()
+	ctx := r.Context()
+	logger := log.FromContext(ctx)
 
 	targetUUID, err := extractPathSuffix(r.URL.Path, OperatorTargetsPath+"/")
 	if err != nil {
@@ -369,9 +380,10 @@ func (h *Handler) UpdateTarget(w http.ResponseWriter, r *http.Request) {
 
 	var req UpdateTargetRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		logger.Error(err, "Failed to decode update target request body")
 		writeJSONError(w, http.StatusBadRequest, ErrorResponse{
 			Error:   "bad_request",
-			Message: "Invalid request body: " + err.Error(),
+			Message: "Invalid request body",
 		})
 		return
 	}
@@ -397,18 +409,20 @@ func (h *Handler) UpdateTarget(w http.ResponseWriter, r *http.Request) {
 		Name:      target.Spec.SecretUUID,
 		Namespace: h.namespace,
 	}, &secret); err != nil {
+		logger.Error(err, "Failed to get secret", "secretUUID", target.Spec.SecretUUID)
 		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
 			Error:   "internal_error",
-			Message: "Failed to get secret: " + err.Error(),
+			Message: "Failed to get secret",
 		})
 		return
 	}
 
 	secretData, err := kubeconfig.MarshalSecretData(kubeconfigBase64)
 	if err != nil {
+		logger.Error(err, "Failed to marshal secret data")
 		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
 			Error:   "internal_error",
-			Message: "Failed to marshal secret data: " + err.Error(),
+			Message: "Failed to marshal secret data",
 		})
 		return
 	}
@@ -416,9 +430,10 @@ func (h *Handler) UpdateTarget(w http.ResponseWriter, r *http.Request) {
 	secret.Data["kubeconfig"] = secretData
 
 	if err := h.client.Update(ctx, &secret); err != nil {
+		logger.Error(err, "Failed to update secret", "secretUUID", target.Spec.SecretUUID)
 		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
 			Error:   "internal_error",
-			Message: "Failed to update secret: " + err.Error(),
+			Message: "Failed to update secret",
 		})
 		return
 	}
@@ -434,9 +449,10 @@ func (h *Handler) UpdateTarget(w http.ResponseWriter, r *http.Request) {
 	target.Status.LastUpdated = metav1.Now()
 
 	if err := h.client.Update(ctx, target); err != nil {
+		logger.Error(err, "Failed to update target", "targetUUID", targetUUID)
 		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
 			Error:   "internal_error",
-			Message: "Failed to update target: " + err.Error(),
+			Message: "Failed to update target",
 		})
 		return
 	}
@@ -452,7 +468,8 @@ func (h *Handler) UpdateTarget(w http.ResponseWriter, r *http.Request) {
 // DeleteTarget handles DELETE /api/v1/operator/targets/{uuid}
 // Deletes a KrknOperatorTarget and its associated Secret
 func (h *Handler) DeleteTarget(w http.ResponseWriter, r *http.Request) {
-	ctx := context.Background()
+	ctx := r.Context()
+	logger := log.FromContext(ctx)
 
 	targetUUID, err := extractPathSuffix(r.URL.Path, OperatorTargetsPath+"/")
 	if err != nil {
@@ -480,9 +497,10 @@ func (h *Handler) DeleteTarget(w http.ResponseWriter, r *http.Request) {
 	_ = h.client.Delete(ctx, secret)
 
 	if err := h.client.Delete(ctx, target); err != nil {
+		logger.Error(err, "Failed to delete target", "targetUUID", targetUUID)
 		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
 			Error:   "internal_error",
-			Message: "Failed to delete target: " + err.Error(),
+			Message: "Failed to delete target",
 		})
 		return
 	}
@@ -546,13 +564,17 @@ func (h *Handler) TargetsCRUDRouter(w http.ResponseWriter, r *http.Request) {
 
 // writeTargetFetchError writes appropriate error response based on the fetch error.
 func (h *Handler) writeTargetFetchError(w http.ResponseWriter, err error) {
-	statusCode := http.StatusInternalServerError
 	if strings.Contains(err.Error(), "not found") {
-		statusCode = http.StatusNotFound
+		writeJSONError(w, http.StatusNotFound, ErrorResponse{
+			Error:   "not_found",
+			Message: err.Error(),
+		})
+		return
 	}
-	writeJSONError(w, statusCode, ErrorResponse{
-		Error:   "error",
-		Message: err.Error(),
+	log.Log.WithName("api").Error(err, "Failed to get target")
+	writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
+		Error:   "internal_error",
+		Message: "Failed to get target",
 	})
 }
 

--- a/internal/controller/krknscenariorun_controller.go
+++ b/internal/controller/krknscenariorun_controller.go
@@ -281,7 +281,7 @@ func (r *KrknScenarioRunReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 				ClusterAPIURL:  outcome.target.clusterAPIURL,
 				JobID:          uuid.New().String(),
 				Phase:          "Failed",
-				Message:        fmt.Sprintf("Job creation failed: %v", outcome.err),
+				Message:        "Job creation failed",
 				FailureReason:  "JobCreationFailed",
 				StartTime:      &now,
 				CompletionTime: &now,


### PR DESCRIPTION
## Summary
- Replace `context.Background()` with `r.Context()` in all API handlers (`targets_crud.go`, `provider_config_handlers.go`) to properly propagate request-scoped context (cancellation, deadlines, tracing)
- Sanitize error messages returned to clients by logging detailed errors server-side and returning generic messages, preventing internal implementation details from leaking to callers
- Fix wrong HTTP status code in `PostProviderConfig` (`http.StatusProcessing` 102 -> `http.StatusAccepted` 202)
- Sanitize error in CRD status message in `krknscenariorun_controller.go` (write generic message, log full error)
- Fix WebSocket error messages in `handlers.go` to not include raw error details

## Test plan
- [x] `go build ./...` compiles successfully
- [x] `go test ./internal/api/... ./internal/controller/...` all tests pass
- [ ] Verify API error responses no longer contain internal error details
- [ ] Verify server-side logs still contain full error information for debugging

🤖 Generated with [Claude Code](https://claude.com/claude-code)