### PR TITLE
fix(security): improve operational security (token masking, audit logging)

### DIFF
--- a/internal/api/auth_handlers.go
+++ b/internal/api/auth_handlers.go
@@ -357,6 +357,8 @@ func (h *Handler) Register(w http.ResponseWriter, r *http.Request) {
 		// The user is created, just the status needs manual fix
 	}
 
+	// PII notice: userId may be an email address. This audit log entry is necessary
+	// for security monitoring but is subject to data protection requirements (e.g. GDPR).
 	logger.Info("User registered successfully", "userId", req.UserID, "role", req.Role)
 
 	writeJSON(w, http.StatusCreated, RegisterResponse{
@@ -514,6 +516,8 @@ func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
 		// Non-critical error, continue
 	}
 
+	// PII notice: userId may be an email address. This audit log entry is necessary
+	// for security monitoring but is subject to data protection requirements (e.g. GDPR).
 	logger.Info("User logged in successfully", "userId", user.Spec.UserID)
 
 	expiresAt := time.Now().Add(TokenDuration).Format(time.RFC3339)

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -624,6 +624,16 @@ func convertInputFields(fields []typing.InputField) []InputFieldResponse {
 	return result
 }
 
+// maskToken redacts the middle of a sensitive token string for safe logging.
+// It preserves the first 10 and last 10 characters, replacing the rest with "...".
+// Tokens shorter than 20 characters are fully masked as "***".
+func maskToken(token string) string {
+	if len(token) <= 20 {
+		return "***"
+	}
+	return token[:10] + "..." + token[len(token)-10:]
+}
+
 // writeJSON writes a JSON response with the given status code
 func writeJSON(w http.ResponseWriter, status int, data interface{}) {
 	w.Header().Set("Content-Type", "application/json")
@@ -644,6 +654,9 @@ func writeJSONError(w http.ResponseWriter, status int, err ErrorResponse) {
 // callGetNodesGRPC calls the data provider gRPC service to get nodes
 func (h *Handler) callGetNodesGRPC(kubeconfigBase64 string) ([]string, error) {
 	// Create gRPC connection
+	// NOTE: insecure.NewCredentials() is acceptable here because the gRPC data provider
+	// runs as a sidecar container within the same pod, communicating over localhost.
+	// For cross-node or external gRPC communication, TLS credentials must be used instead.
 	conn, err := grpc.NewClient(
 		h.grpcServerAddr,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -1710,7 +1723,7 @@ func (h *Handler) GetScenarioRunLogs(w http.ResponseWriter, r *http.Request) {
 	// Format: "access_token.<jwt_token>"
 	protocols := r.Header.Get("Sec-WebSocket-Protocol")
 	logger.V(1).Info("📋 Received WebSocket headers",
-		"Sec-WebSocket-Protocol", protocols,
+		"Sec-WebSocket-Protocol", maskToken(protocols),
 		"Sec-WebSocket-Version", r.Header.Get("Sec-WebSocket-Version"),
 		"Sec-WebSocket-Key", r.Header.Get("Sec-WebSocket-Key"))
 
@@ -1726,7 +1739,7 @@ func (h *Handler) GetScenarioRunLogs(w http.ResponseWriter, r *http.Request) {
 	// Parse protocol: split on first '.' to separate prefix from token
 	// Example: "access_token.eyJhbGc..." → ["access_token", "eyJhbGc..."]
 	logger.V(1).Info("🔍 Parsing Sec-WebSocket-Protocol",
-		"raw_protocol", protocols,
+		"raw_protocol", maskToken(protocols),
 		"protocol_length", len(protocols))
 
 	protocolParts := strings.SplitN(protocols, ".", 2)
@@ -1765,13 +1778,7 @@ func (h *Handler) GetScenarioRunLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Mask token for logging (show first/last 10 chars)
-	maskedToken := func() string {
-		if len(token) <= 20 {
-			return "***"
-		}
-		return token[:10] + "..." + token[len(token)-10:]
-	}()
+	maskedToken := maskToken(token)
 
 	logger.Info("🔑 JWT token extracted from subprotocol",
 		"token_length", len(token),

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1588,3 +1588,46 @@ func TestConvertInputFields(t *testing.T) {
 		})
 	}
 }
+
+func TestMaskToken(t *testing.T) {
+	tests := []struct {
+		name     string
+		token    string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			token:    "",
+			expected: "***",
+		},
+		{
+			name:     "short token under 20 chars",
+			token:    "abcdef",
+			expected: "***",
+		},
+		{
+			name:     "exactly 20 chars",
+			token:    "12345678901234567890",
+			expected: "***",
+		},
+		{
+			name:     "21 chars shows first 10 and last 10",
+			token:    "123456789012345678901",
+			expected: "1234567890...2345678901",
+		},
+		{
+			name:     "long JWT-like token",
+			token:    "access_token.eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature",
+			expected: "access_tok....signature",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := maskToken(tt.token)
+			if result != tt.expected {
+				t.Errorf("maskToken(%q) = %q, want %q", tt.token, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -308,6 +308,9 @@ func (s *Server) Start(ctx context.Context) error {
 startServer:
 	errChan := make(chan error, 1)
 	go func() {
+		// NOTE: The server listens on plain HTTP. TLS termination is expected to be
+		// handled externally by the Kubernetes Ingress controller, service mesh
+		// (e.g. Istio), or a reverse proxy in front of this service.
 		if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			errChan <- err
 		}
@@ -330,7 +333,13 @@ func (s *Server) Shutdown() error {
 	return s.server.Shutdown(ctx)
 }
 
-// loggingMiddleware is a logging middleware for HTTP requests
+// loggingMiddleware is a logging middleware for HTTP requests.
+//
+// PII notice: This middleware logs client IP addresses (RemoteAddr) and raw query
+// parameters, which may contain personally identifiable information. Operators
+// should ensure log retention and access policies comply with applicable data
+// protection regulations (e.g. GDPR). Consider configuring log scrubbing in the
+// log aggregation pipeline if query parameters may carry sensitive values.
 func loggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()

--- a/internal/api/terminal_handlers.go
+++ b/internal/api/terminal_handlers.go
@@ -218,6 +218,9 @@ func (h *Handler) ExecuteTerminal(w http.ResponseWriter, r *http.Request) {
 // executeKubectlViaGRPC executes a kubectl command via the gRPC data provider
 func (h *Handler) executeKubectlViaGRPC(ctx context.Context, kubeconfigBase64 string, cmd *terminal.ParsedCommand) (*TerminalResponse, error) {
 	// Connect to gRPC server
+	// NOTE: insecure.NewCredentials() is acceptable here because the gRPC data provider
+	// runs as a sidecar container within the same pod, communicating over localhost.
+	// For cross-node or external gRPC communication, TLS credentials must be used instead.
 	conn, err := grpc.NewClient(h.grpcServerAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to gRPC server: %w", err)

--- a/internal/api/user_handlers.go
+++ b/internal/api/user_handlers.go
@@ -858,6 +858,13 @@ func (h *Handler) ChangePassword(w http.ResponseWriter, r *http.Request) {
 
 	logger.Info("Password updated successfully", "userID", userID)
 
+	// Audit log: record when an admin changes another user's password
+	if isAdmin && !isSelf {
+		logger.Info("admin changed user password",
+			"admin", claims.UserID,
+			"targetUser", userID)
+	}
+
 	writeJSON(w, http.StatusOK, ChangePasswordResponse{
 		Message: "Password updated successfully",
 	})


### PR DESCRIPTION
## Summary

- **Token masking**: Add `maskToken()` helper and apply it to WebSocket debug logs that previously leaked the full JWT via the `Sec-WebSocket-Protocol` header at V(1) verbosity. Refactored the existing inline masking closure to use the same helper.
- **Admin audit log**: Log an explicit audit entry when an admin changes another user's password, recording both admin and target user IDs.
- **TLS documentation**: Added code comments clarifying that `insecure.NewCredentials()` for gRPC is acceptable only for in-pod localhost sidecar communication, and that the HTTP server expects TLS termination at the Ingress/service-mesh layer.
- **PII notices**: Added data protection comments to the logging middleware (client IPs, query params) and auth handler log entries (user IDs as email addresses).

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./internal/api/...` passes (including new `TestMaskToken` table-driven tests)
- [ ] Verify at V(1) log verbosity that WebSocket protocol headers are masked
- [ ] Verify admin password change produces audit log entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)