### PR TITLE
fix(security): fix authorization bypass risks in sanitizeUserID and cluster name mapping

### DIFF
--- a/internal/api/authorization.go
+++ b/internal/api/authorization.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 
 	krknv1alpha1 "github.com/krkn-chaos/krkn-operator/api/v1alpha1"
 	"github.com/krkn-chaos/krkn-operator/pkg/auth"
@@ -57,17 +56,6 @@ func (h *Handler) requireAdminForMethods(w http.ResponseWriter, r *http.Request,
 	}
 
 	return true
-}
-
-// sanitizeUserID converts an email address to a valid Kubernetes label value.
-// Replaces @ and . with -, then converts to lowercase to comply with
-// Kubernetes label value requirements (RFC 1123).
-//
-// Example: "user@example.com" -> "user-example-com"
-func sanitizeUserID(email string) string {
-	sanitized := strings.ReplaceAll(email, "@", "-")
-	sanitized = strings.ReplaceAll(sanitized, ".", "-")
-	return strings.ToLower(sanitized)
 }
 
 // checkScenarioRunAccess verifies if the authenticated user has permission to access

--- a/internal/api/files_handlers_test.go
+++ b/internal/api/files_handlers_test.go
@@ -34,6 +34,7 @@ import (
 	krknv1alpha1 "github.com/krkn-chaos/krkn-operator/api/v1alpha1"
 	"github.com/krkn-chaos/krkn-operator/pkg/auth"
 	"github.com/krkn-chaos/krkn-operator/pkg/files"
+	"github.com/krkn-chaos/krkn-operator/pkg/groupauth"
 )
 
 // setupFilesTestHandler creates a test Handler with fake client
@@ -254,7 +255,7 @@ func TestCreateFile(t *testing.T) {
 					userLabels[labelKey] = "true"
 				}
 
-				userName := "krknuser-" + sanitizeUserID(tt.userID)
+				userName := groupauth.SanitizeUserIDForResourceName(tt.userID)
 				role := "user"
 				if tt.isAdmin {
 					role = "admin"
@@ -694,7 +695,7 @@ func TestUpdateFile(t *testing.T) {
 					userLabels[labelKey] = "true"
 				}
 
-				userName := "krknuser-" + sanitizeUserID(tt.userID)
+				userName := groupauth.SanitizeUserIDForResourceName(tt.userID)
 				role := "user"
 				if tt.isAdmin {
 					role = "admin"
@@ -912,7 +913,7 @@ func TestDeleteFile(t *testing.T) {
 					userLabels[labelKey] = "true"
 				}
 
-				userName := "krknuser-" + sanitizeUserID(tt.userID)
+				userName := groupauth.SanitizeUserIDForResourceName(tt.userID)
 				role := "user"
 				if tt.isAdmin {
 					role = "admin"
@@ -1242,7 +1243,7 @@ func TestCanAccessFile(t *testing.T) {
 func createTestAdminUser(handler *Handler) {
 	user := &krknv1alpha1.KrknUser{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "krknuser-" + sanitizeUserID("admin@test.example"),
+			Name:      groupauth.SanitizeUserIDForResourceName("admin@test.example"),
 			Namespace: handler.namespace,
 		},
 		Spec: krknv1alpha1.KrknUserSpec{

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -439,7 +439,7 @@ func (h *Handler) PostTarget(w http.ResponseWriter, r *http.Request) {
 	// Build labels with owner tracking
 	labels := make(map[string]string)
 	if claims != nil {
-		labels["krkn.krkn-chaos.dev/owner-user"] = sanitizeUserID(claims.UserID)
+		labels["krkn.krkn-chaos.dev/owner-user"] = groupauth.SanitizeUserIDForLabel(claims.UserID)
 	}
 
 	// Create a new KrknTargetRequest CR
@@ -553,7 +553,7 @@ func (h *Handler) DeleteTargetByUUID(w http.ResponseWriter, r *http.Request) {
 
 	// Extract owner from label
 	ownerLabel := targetRequest.Labels["krkn.krkn-chaos.dev/owner-user"]
-	currentUserSanitized := sanitizeUserID(claims.UserID)
+	currentUserSanitized := groupauth.SanitizeUserIDForLabel(claims.UserID)
 
 	if ownerLabel != currentUserSanitized {
 		logger.Info("Denying delete - user is not the owner",
@@ -1389,7 +1389,7 @@ func (h *Handler) PostScenarioRun(w http.ResponseWriter, r *http.Request) {
 	labels := make(map[string]string)
 	ownerUserID := ""
 	if claims != nil {
-		labels["krkn.krkn-chaos.dev/owner-user"] = sanitizeUserID(claims.UserID)
+		labels["krkn.krkn-chaos.dev/owner-user"] = groupauth.SanitizeUserIDForLabel(claims.UserID)
 		ownerUserID = claims.UserID
 	}
 	if req.CustomRunName != "" {

--- a/internal/api/scenario_run_authorization_test.go
+++ b/internal/api/scenario_run_authorization_test.go
@@ -33,11 +33,13 @@ import (
 
 	krknv1alpha1 "github.com/krkn-chaos/krkn-operator/api/v1alpha1"
 	"github.com/krkn-chaos/krkn-operator/pkg/auth"
+	"github.com/krkn-chaos/krkn-operator/pkg/groupauth"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-// TestSanitizeUserID tests the email sanitization for Kubernetes labels
-func TestSanitizeUserID(t *testing.T) {
+// TestSanitizeUserIDForLabel tests the email sanitization for Kubernetes labels
+// via the consolidated groupauth.SanitizeUserIDForLabel function.
+func TestSanitizeUserIDForLabel(t *testing.T) {
 	tests := []struct {
 		name     string
 		email    string
@@ -67,9 +69,9 @@ func TestSanitizeUserID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := sanitizeUserID(tt.email)
+			result := groupauth.SanitizeUserIDForLabel(tt.email)
 			if result != tt.expected {
-				t.Errorf("sanitizeUserID(%s) = %s, want %s", tt.email, result, tt.expected)
+				t.Errorf("SanitizeUserIDForLabel(%s) = %s, want %s", tt.email, result, tt.expected)
 			}
 		})
 	}

--- a/internal/api/workflow_handlers_test.go
+++ b/internal/api/workflow_handlers_test.go
@@ -33,6 +33,7 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	krknv1alpha1 "github.com/krkn-chaos/krkn-operator/api/v1alpha1"
+	"github.com/krkn-chaos/krkn-operator/pkg/groupauth"
 	"github.com/krkn-chaos/krkn-operator/pkg/workflows"
 )
 
@@ -206,7 +207,7 @@ func TestCreateWorkflow(t *testing.T) {
 			for _, group := range tt.userGroups {
 				labels["group.krkn.krkn-chaos.dev/"+group] = "true"
 			}
-			userName := "krknuser-" + sanitizeUserID(tt.userID)
+			userName := groupauth.SanitizeUserIDForResourceName(tt.userID)
 			user := &krknv1alpha1.KrknUser{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      userName,
@@ -434,7 +435,7 @@ func TestListAvailableWorkflows(t *testing.T) {
 	}
 
 	// Create user
-	userName := "krknuser-" + sanitizeUserID("user@test.example")
+	userName := groupauth.SanitizeUserIDForResourceName("user@test.example")
 	user := &krknv1alpha1.KrknUser{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      userName,
@@ -620,7 +621,7 @@ func TestNodeCountAccuracy(t *testing.T) {
 		t.Fatalf("Failed to create test workflow: %v", err)
 	}
 
-	userName := "krknuser-" + sanitizeUserID("admin@test.example")
+	userName := groupauth.SanitizeUserIDForResourceName("admin@test.example")
 	user := &krknv1alpha1.KrknUser{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      userName,
@@ -829,7 +830,7 @@ func TestCreateWorkflow_DuplicateName(t *testing.T) {
 	// Create user
 	user := &krknv1alpha1.KrknUser{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "krknuser-" + sanitizeUserID("admin@test.example"),
+			Name:      groupauth.SanitizeUserIDForResourceName("admin@test.example"),
 			Namespace: handler.namespace,
 		},
 		Spec: krknv1alpha1.KrknUserSpec{
@@ -878,7 +879,7 @@ func TestUpdateWorkflow_RenameConflict(t *testing.T) {
 	// Create user
 	user := &krknv1alpha1.KrknUser{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "krknuser-" + sanitizeUserID("admin@test.example"),
+			Name:      groupauth.SanitizeUserIDForResourceName("admin@test.example"),
 			Namespace: handler.namespace,
 		},
 		Spec: krknv1alpha1.KrknUserSpec{

--- a/pkg/groupauth/permissions.go
+++ b/pkg/groupauth/permissions.go
@@ -43,7 +43,7 @@ func GetUserGroups(ctx context.Context, k8sClient client.Client, userID, namespa
 	logger := log.FromContext(ctx).WithName("groupauth.GetUserGroups")
 
 	// Fetch KrknUser by email
-	userName := sanitizeUserID(userID)
+	userName := SanitizeUserIDForResourceName(userID)
 	user := &krknv1alpha1.KrknUser{}
 	if err := k8sClient.Get(ctx, client.ObjectKey{Name: userName, Namespace: namespace}, user); err != nil {
 		return nil, fmt.Errorf("failed to get user %s: %w", userID, err)
@@ -195,13 +195,23 @@ func CountGroupMembers(ctx context.Context, k8sClient client.Client, groupName, 
 	return len(userList.Items), nil
 }
 
-// sanitizeUserID converts an email address to a valid Kubernetes resource name.
-// Replaces @ and . with -, converts to lowercase, and adds prefix.
+// SanitizeUserIDForResourceName converts an email address to a valid Kubernetes resource name.
+// It replaces @ and . with -, converts to lowercase, and adds the "krknuser-" prefix.
+// Use this when constructing a KrknUser resource name for Kubernetes API lookups.
 //
 // Example: "user@example.com" -> "krknuser-user-example-com"
-func sanitizeUserID(email string) string {
-	name := strings.ReplaceAll(email, "@", "-")
-	name = strings.ReplaceAll(name, ".", "-")
-	name = strings.ToLower(name)
-	return fmt.Sprintf("krknuser-%s", name)
+func SanitizeUserIDForResourceName(email string) string {
+	return fmt.Sprintf("krknuser-%s", SanitizeUserIDForLabel(email))
+}
+
+// SanitizeUserIDForLabel converts an email address to a valid Kubernetes label value.
+// It replaces @ and . with -, then converts to lowercase to comply with
+// Kubernetes label value requirements (RFC 1123). No prefix is added.
+// Use this when setting or comparing owner-user labels on Kubernetes resources.
+//
+// Example: "user@example.com" -> "user-example-com"
+func SanitizeUserIDForLabel(email string) string {
+	sanitized := strings.ReplaceAll(email, "@", "-")
+	sanitized = strings.ReplaceAll(sanitized, ".", "-")
+	return strings.ToLower(sanitized)
 }

--- a/pkg/groupauth/permissions_test.go
+++ b/pkg/groupauth/permissions_test.go
@@ -497,7 +497,7 @@ func TestCountGroupMembers(t *testing.T) {
 	}
 }
 
-func TestSanitizeUserID(t *testing.T) {
+func TestSanitizeUserIDForResourceName(t *testing.T) {
 	tests := []struct {
 		name  string
 		email string
@@ -518,14 +518,82 @@ func TestSanitizeUserID(t *testing.T) {
 			email: "User@Example.Com",
 			want:  "krknuser-user-example-com",
 		},
+		{
+			name:  "email with dots in username",
+			email: "john.doe@company.org",
+			want:  "krknuser-john-doe-company-org",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := sanitizeUserID(tt.email)
+			got := SanitizeUserIDForResourceName(tt.email)
 			if got != tt.want {
-				t.Errorf("sanitizeUserID() = %q, want %q", got, tt.want)
+				t.Errorf("SanitizeUserIDForResourceName() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSanitizeUserIDForLabel(t *testing.T) {
+	tests := []struct {
+		name  string
+		email string
+		want  string
+	}{
+		{
+			name:  "standard email",
+			email: "user@example.com",
+			want:  "user-example-com",
+		},
+		{
+			name:  "email with subdomain",
+			email: "user@mail.example.com",
+			want:  "user-mail-example-com",
+		},
+		{
+			name:  "uppercase email",
+			email: "User@Example.Com",
+			want:  "user-example-com",
+		},
+		{
+			name:  "email with dots in username",
+			email: "john.doe@company.org",
+			want:  "john-doe-company-org",
+		},
+		{
+			name:  "complex email",
+			email: "test.user.dev@example.co.uk",
+			want:  "test-user-dev-example-co-uk",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizeUserIDForLabel(tt.email)
+			if got != tt.want {
+				t.Errorf("SanitizeUserIDForLabel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeUserIDConsistency(t *testing.T) {
+	// Verify that SanitizeUserIDForResourceName is composed of
+	// "krknuser-" + SanitizeUserIDForLabel for any input
+	emails := []string{
+		"user@example.com",
+		"Admin@Test.COM",
+		"john.doe@mail.example.co.uk",
+	}
+
+	for _, email := range emails {
+		resourceName := SanitizeUserIDForResourceName(email)
+		labelValue := SanitizeUserIDForLabel(email)
+		expected := "krknuser-" + labelValue
+		if resourceName != expected {
+			t.Errorf("SanitizeUserIDForResourceName(%q) = %q, but expected krknuser- + SanitizeUserIDForLabel = %q",
+				email, resourceName, expected)
+		}
 	}
 }

--- a/pkg/groupauth/validation.go
+++ b/pkg/groupauth/validation.go
@@ -69,7 +69,10 @@ func ValidateScenarioRunAccess(
 	aggregatedPermissions := AggregateClusterPermissions(userGroups)
 
 	// 3. Build clusterName -> apiURL mapping from TargetRequest
-	clusterAPIURLMap := buildClusterAPIURLMap(targetRequest)
+	clusterAPIURLMap, err := buildClusterAPIURLMap(targetRequest)
+	if err != nil {
+		return fmt.Errorf("failed to build cluster API URL map: %w", err)
+	}
 
 	// 4. Validate each target cluster
 	for provider, clusterNames := range targetClusters {
@@ -163,17 +166,22 @@ func FilterClustersByPermission(
 	return filtered, nil
 }
 
-// buildClusterAPIURLMap builds a map from cluster name to API URL
-func buildClusterAPIURLMap(targetRequest *krknv1alpha1.KrknTargetRequest) map[string]string {
+// buildClusterAPIURLMap builds a map from cluster name to API URL.
+// Returns an error if two providers register the same cluster name with different API URLs,
+// which would indicate a cluster name collision that could lead to authorization bypass.
+func buildClusterAPIURLMap(targetRequest *krknv1alpha1.KrknTargetRequest) (map[string]string, error) {
 	result := make(map[string]string)
 
 	for _, targets := range targetRequest.Status.TargetData {
 		for _, cluster := range targets {
+			if existing, ok := result[cluster.ClusterName]; ok && existing != cluster.ClusterAPIURL {
+				return nil, fmt.Errorf("cluster name collision: %q registered by multiple providers with different API URLs (%s vs %s)", cluster.ClusterName, existing, cluster.ClusterAPIURL)
+			}
 			result[cluster.ClusterName] = cluster.ClusterAPIURL
 		}
 	}
 
-	return result
+	return result, nil
 }
 
 // countClusters counts total clusters in targetClusters map

--- a/pkg/groupauth/validation_test.go
+++ b/pkg/groupauth/validation_test.go
@@ -401,7 +401,10 @@ func TestBuildClusterAPIURLMap(t *testing.T) {
 		},
 	}
 
-	result := buildClusterAPIURLMap(targetRequest)
+	result, err := buildClusterAPIURLMap(targetRequest)
+	if err != nil {
+		t.Fatalf("buildClusterAPIURLMap() unexpected error: %v", err)
+	}
 
 	expected := map[string]string{
 		"cluster1": "https://api.cluster1.com",
@@ -422,6 +425,72 @@ func TestBuildClusterAPIURLMap(t *testing.T) {
 		if gotURL != wantURL {
 			t.Errorf("buildClusterAPIURLMap() cluster %s = %s, want %s", clusterName, gotURL, wantURL)
 		}
+	}
+}
+
+func TestBuildClusterAPIURLMap_SameNameSameURL(t *testing.T) {
+	// Same cluster name with same API URL across providers is allowed (idempotent)
+	targetRequest := &krknv1alpha1.KrknTargetRequest{
+		Status: krknv1alpha1.KrknTargetRequestStatus{
+			TargetData: map[string][]krknv1alpha1.ClusterTarget{
+				"provider1": {
+					{
+						ClusterName:   "shared-cluster",
+						ClusterAPIURL: "https://api.shared.com",
+					},
+				},
+				"provider2": {
+					{
+						ClusterName:   "shared-cluster",
+						ClusterAPIURL: "https://api.shared.com",
+					},
+				},
+			},
+		},
+	}
+
+	result, err := buildClusterAPIURLMap(targetRequest)
+	if err != nil {
+		t.Fatalf("buildClusterAPIURLMap() should not error when same cluster has same URL, got: %v", err)
+	}
+
+	if url, ok := result["shared-cluster"]; !ok || url != "https://api.shared.com" {
+		t.Errorf("buildClusterAPIURLMap() shared-cluster = %q, want %q", url, "https://api.shared.com")
+	}
+}
+
+func TestBuildClusterAPIURLMap_Collision(t *testing.T) {
+	// Same cluster name with DIFFERENT API URLs across providers must return an error
+	targetRequest := &krknv1alpha1.KrknTargetRequest{
+		Status: krknv1alpha1.KrknTargetRequestStatus{
+			TargetData: map[string][]krknv1alpha1.ClusterTarget{
+				"provider1": {
+					{
+						ClusterName:   "cluster1",
+						ClusterAPIURL: "https://api.provider1-cluster1.com",
+					},
+				},
+				"provider2": {
+					{
+						ClusterName:   "cluster1",
+						ClusterAPIURL: "https://api.provider2-cluster1.com",
+					},
+				},
+			},
+		},
+	}
+
+	_, err := buildClusterAPIURLMap(targetRequest)
+	if err == nil {
+		t.Fatal("buildClusterAPIURLMap() should return error for cluster name collision with different API URLs")
+	}
+
+	if !contains(err.Error(), "cluster name collision") {
+		t.Errorf("buildClusterAPIURLMap() error should mention collision, got: %v", err)
+	}
+
+	if !contains(err.Error(), "cluster1") {
+		t.Errorf("buildClusterAPIURLMap() error should mention the colliding cluster name, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Consolidated two divergent `sanitizeUserID` functions (one with `krknuser-` prefix in `pkg/groupauth`, one without in `internal/api`) into two clearly-named exported functions: `SanitizeUserIDForResourceName` (with prefix, for K8s resource lookups) and `SanitizeUserIDForLabel` (without prefix, for K8s label values). The previous divergent private implementations could lead to identity confusion between resource names and label values.
- Added cluster name collision detection in `buildClusterAPIURLMap`: if two providers register the same cluster name with different API URLs, the function now returns an error instead of silently overwriting. This prevents authorization bypass where a malicious provider could shadow a legitimate cluster.
- Added comprehensive tests covering both sanitization variants, their consistency, and the cluster name collision scenario.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/groupauth/...` passes (including new `TestSanitizeUserIDForResourceName`, `TestSanitizeUserIDForLabel`, `TestSanitizeUserIDConsistency`, `TestBuildClusterAPIURLMap_Collision`, `TestBuildClusterAPIURLMap_SameNameSameURL`)
- [x] `go test ./internal/api/...` passes (updated test references)
- [x] Existing tests continue to pass with updated function references

🤖 Generated with [Claude Code](https://claude.com/claude-code)