### PR TITLE
feat(security): add rate limiting, user status validation, and WebSocket origin checks

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1656,10 +1656,7 @@ func (h *Handler) GetScenarioRunStatus(w http.ResponseWriter, r *http.Request) {
 var upgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
-	CheckOrigin: func(r *http.Request) bool {
-		// Allow all origins for now - in production you should validate the origin
-		return true
-	},
+	CheckOrigin:     checkWebSocketOrigin,
 	// Support "access_token" subprotocol for JWT authentication
 	Subprotocols: []string{"access_token"},
 }

--- a/internal/api/rate_limiter.go
+++ b/internal/api/rate_limiter.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// ipRateLimiter provides per-IP rate limiting for HTTP endpoints.
+// It maintains a map of rate limiters keyed by client IP address,
+// with automatic cleanup of stale entries to prevent memory leaks.
+type ipRateLimiter struct {
+	mu       sync.Mutex
+	limiters map[string]*rateLimiterEntry
+	rate     rate.Limit
+	burst    int
+}
+
+// rateLimiterEntry holds a rate limiter and its last-seen timestamp
+// for cleanup of stale entries.
+type rateLimiterEntry struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
+// newIPRateLimiter creates a new per-IP rate limiter.
+//
+// Parameters:
+//   - r: the rate limit (events per second). Use rate.Every(d) for time-based rates.
+//   - b: the burst size (maximum number of events allowed in a single burst).
+//
+// Returns a new ipRateLimiter instance.
+func newIPRateLimiter(r rate.Limit, b int) *ipRateLimiter {
+	rl := &ipRateLimiter{
+		limiters: make(map[string]*rateLimiterEntry),
+		rate:     r,
+		burst:    b,
+	}
+	return rl
+}
+
+// getLimiter returns the rate limiter for the given IP address,
+// creating one if it does not already exist. Updates the last-seen
+// timestamp on each access.
+func (i *ipRateLimiter) getLimiter(ip string) *rate.Limiter {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	entry, exists := i.limiters[ip]
+	if !exists {
+		entry = &rateLimiterEntry{
+			limiter:  rate.NewLimiter(i.rate, i.burst),
+			lastSeen: time.Now(),
+		}
+		i.limiters[ip] = entry
+		return entry.limiter
+	}
+
+	entry.lastSeen = time.Now()
+	return entry.limiter
+}
+
+// cleanup removes entries that have not been seen for longer than maxAge.
+// This prevents unbounded memory growth from unique IPs.
+func (i *ipRateLimiter) cleanup(maxAge time.Duration) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	cutoff := time.Now().Add(-maxAge)
+	for ip, entry := range i.limiters {
+		if entry.lastSeen.Before(cutoff) {
+			delete(i.limiters, ip)
+		}
+	}
+}
+
+// startCleanup starts a background goroutine that periodically removes stale
+// rate limiter entries. The goroutine stops when the provided stop channel is closed.
+//
+// Parameters:
+//   - interval: how often to run cleanup (e.g., 10 minutes)
+//   - maxAge: entries not seen within this duration are removed (e.g., 10 minutes)
+//   - stop: channel that signals the goroutine to exit
+func (i *ipRateLimiter) startCleanup(interval, maxAge time.Duration, stop <-chan struct{}) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				i.cleanup(maxAge)
+				logger := log.Log.WithName("rate-limiter")
+				i.mu.Lock()
+				count := len(i.limiters)
+				i.mu.Unlock()
+				logger.V(1).Info("Rate limiter cleanup completed", "activeEntries", count)
+			case <-stop:
+				return
+			}
+		}
+	}()
+}
+
+// extractClientIP extracts the client IP address from an HTTP request.
+// It checks X-Forwarded-For and X-Real-IP headers first (for reverse proxy setups),
+// then falls back to RemoteAddr.
+func extractClientIP(r *http.Request) string {
+	// Check X-Forwarded-For header (may contain multiple IPs: client, proxy1, proxy2)
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		// Take the first IP (the original client)
+		parts := strings.SplitN(xff, ",", 2)
+		ip := strings.TrimSpace(parts[0])
+		if ip != "" {
+			return ip
+		}
+	}
+
+	// Check X-Real-IP header
+	if xri := r.Header.Get("X-Real-IP"); xri != "" {
+		return strings.TrimSpace(xri)
+	}
+
+	// Fall back to RemoteAddr (includes port)
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		// RemoteAddr might not have a port
+		return r.RemoteAddr
+	}
+	return host
+}
+
+// rateLimitMiddleware creates an HTTP middleware that enforces per-IP rate limiting.
+// When a client exceeds the rate limit, it receives a 429 Too Many Requests response.
+//
+// Parameters:
+//   - limiter: the per-IP rate limiter to use
+//
+// Returns a middleware function that wraps an http.Handler.
+func rateLimitMiddleware(limiter *ipRateLimiter) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ip := extractClientIP(r)
+			if !limiter.getLimiter(ip).Allow() {
+				logger := log.Log.WithName("rate-limiter")
+				logger.Info("Rate limit exceeded",
+					"client_ip", ip,
+					"path", r.URL.Path,
+					"method", r.Method,
+				)
+				writeJSONError(w, http.StatusTooManyRequests, ErrorResponse{
+					Error:   "rate_limited",
+					Message: "Too many requests, please try again later",
+				})
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/api/rate_limiter_test.go
+++ b/internal/api/rate_limiter_test.go
@@ -1,0 +1,318 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+func TestIPRateLimiter_AllowsUnderLimit(t *testing.T) {
+	// Create a limiter with rate of 10/s and burst of 5
+	limiter := newIPRateLimiter(rate.Limit(10), 5)
+
+	ip := "192.168.1.1"
+	rl := limiter.getLimiter(ip)
+
+	// Should allow up to burst size immediately
+	for i := 0; i < 5; i++ {
+		if !rl.Allow() {
+			t.Errorf("Request %d should have been allowed", i+1)
+		}
+	}
+}
+
+func TestIPRateLimiter_BlocksOverLimit(t *testing.T) {
+	// Create a limiter with very low rate and burst of 2
+	limiter := newIPRateLimiter(rate.Limit(0.01), 2) // 0.01/s = very slow refill
+
+	ip := "10.0.0.1"
+	rl := limiter.getLimiter(ip)
+
+	// Exhaust the burst
+	for i := 0; i < 2; i++ {
+		if !rl.Allow() {
+			t.Fatalf("Initial burst request %d should have been allowed", i+1)
+		}
+	}
+
+	// The next request should be blocked (burst exhausted, rate too slow)
+	if rl.Allow() {
+		t.Error("Request after burst exhaustion should have been blocked")
+	}
+}
+
+func TestIPRateLimiter_SeparateLimitersPerIP(t *testing.T) {
+	limiter := newIPRateLimiter(rate.Limit(0.01), 1) // burst of 1
+
+	// First IP uses its burst
+	rl1 := limiter.getLimiter("10.0.0.1")
+	if !rl1.Allow() {
+		t.Error("First request from IP1 should be allowed")
+	}
+	if rl1.Allow() {
+		t.Error("Second request from IP1 should be blocked")
+	}
+
+	// Second IP should have its own independent limiter
+	rl2 := limiter.getLimiter("10.0.0.2")
+	if !rl2.Allow() {
+		t.Error("First request from IP2 should be allowed (separate limiter)")
+	}
+}
+
+func TestIPRateLimiter_Cleanup(t *testing.T) {
+	limiter := newIPRateLimiter(rate.Limit(1), 1)
+
+	// Access an IP to create an entry
+	limiter.getLimiter("10.0.0.1")
+
+	// Verify entry exists
+	limiter.mu.Lock()
+	if len(limiter.limiters) != 1 {
+		t.Fatalf("Expected 1 entry, got %d", len(limiter.limiters))
+	}
+
+	// Backdating the last-seen time to simulate staleness
+	limiter.limiters["10.0.0.1"].lastSeen = time.Now().Add(-20 * time.Minute)
+	limiter.mu.Unlock()
+
+	// Run cleanup with 10 minute max age
+	limiter.cleanup(10 * time.Minute)
+
+	limiter.mu.Lock()
+	remaining := len(limiter.limiters)
+	limiter.mu.Unlock()
+
+	if remaining != 0 {
+		t.Errorf("Expected 0 entries after cleanup, got %d", remaining)
+	}
+}
+
+func TestIPRateLimiter_CleanupPreservesFresh(t *testing.T) {
+	limiter := newIPRateLimiter(rate.Limit(1), 1)
+
+	// Create two entries
+	limiter.getLimiter("10.0.0.1") // fresh
+	limiter.getLimiter("10.0.0.2") // will be stale
+
+	// Make one stale
+	limiter.mu.Lock()
+	limiter.limiters["10.0.0.2"].lastSeen = time.Now().Add(-20 * time.Minute)
+	limiter.mu.Unlock()
+
+	limiter.cleanup(10 * time.Minute)
+
+	limiter.mu.Lock()
+	remaining := len(limiter.limiters)
+	_, freshExists := limiter.limiters["10.0.0.1"]
+	_, staleExists := limiter.limiters["10.0.0.2"]
+	limiter.mu.Unlock()
+
+	if remaining != 1 {
+		t.Errorf("Expected 1 entry after cleanup, got %d", remaining)
+	}
+	if !freshExists {
+		t.Error("Fresh entry should have been preserved")
+	}
+	if staleExists {
+		t.Error("Stale entry should have been removed")
+	}
+}
+
+func TestExtractClientIP(t *testing.T) {
+	tests := []struct {
+		name       string
+		headers    map[string]string
+		remoteAddr string
+		expectedIP string
+	}{
+		{
+			name:       "from RemoteAddr with port",
+			remoteAddr: "192.168.1.1:12345",
+			expectedIP: "192.168.1.1",
+		},
+		{
+			name:       "from RemoteAddr without port",
+			remoteAddr: "192.168.1.1",
+			expectedIP: "192.168.1.1",
+		},
+		{
+			name:       "from X-Forwarded-For single IP",
+			headers:    map[string]string{"X-Forwarded-For": "10.0.0.1"},
+			remoteAddr: "192.168.1.1:12345",
+			expectedIP: "10.0.0.1",
+		},
+		{
+			name:       "from X-Forwarded-For multiple IPs",
+			headers:    map[string]string{"X-Forwarded-For": "10.0.0.1, 10.0.0.2, 10.0.0.3"},
+			remoteAddr: "192.168.1.1:12345",
+			expectedIP: "10.0.0.1",
+		},
+		{
+			name:       "from X-Real-IP",
+			headers:    map[string]string{"X-Real-IP": "172.16.0.1"},
+			remoteAddr: "192.168.1.1:12345",
+			expectedIP: "172.16.0.1",
+		},
+		{
+			name: "X-Forwarded-For takes priority over X-Real-IP",
+			headers: map[string]string{
+				"X-Forwarded-For": "10.0.0.1",
+				"X-Real-IP":       "172.16.0.1",
+			},
+			remoteAddr: "192.168.1.1:12345",
+			expectedIP: "10.0.0.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/", nil)
+			req.RemoteAddr = tt.remoteAddr
+			for k, v := range tt.headers {
+				req.Header.Set(k, v)
+			}
+
+			ip := extractClientIP(req)
+			if ip != tt.expectedIP {
+				t.Errorf("Expected IP %q, got %q", tt.expectedIP, ip)
+			}
+		})
+	}
+}
+
+func TestRateLimitMiddleware_AllowsNormalTraffic(t *testing.T) {
+	limiter := newIPRateLimiter(rate.Limit(10), 5) // generous limit
+	middleware := rateLimitMiddleware(limiter)
+
+	handlerCalled := false
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := middleware(testHandler)
+
+	req := httptest.NewRequest("POST", "/api/v1/auth/login", nil)
+	req.RemoteAddr = "10.0.0.1:12345"
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
+	}
+	if !handlerCalled {
+		t.Error("Expected handler to be called")
+	}
+}
+
+func TestRateLimitMiddleware_Blocks429(t *testing.T) {
+	// Very restrictive: burst of 1, essentially no refill
+	limiter := newIPRateLimiter(rate.Limit(0.001), 1)
+	middleware := rateLimitMiddleware(limiter)
+
+	handlerCallCount := 0
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCallCount++
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := middleware(testHandler)
+
+	// First request should succeed (uses burst)
+	req1 := httptest.NewRequest("POST", "/api/v1/auth/login", nil)
+	req1.RemoteAddr = "10.0.0.1:12345"
+	w1 := httptest.NewRecorder()
+	handler.ServeHTTP(w1, req1)
+
+	if w1.Code != http.StatusOK {
+		t.Errorf("First request: expected status %d, got %d", http.StatusOK, w1.Code)
+	}
+
+	// Second request should be rate limited
+	req2 := httptest.NewRequest("POST", "/api/v1/auth/login", nil)
+	req2.RemoteAddr = "10.0.0.1:12345"
+	w2 := httptest.NewRecorder()
+	handler.ServeHTTP(w2, req2)
+
+	if w2.Code != http.StatusTooManyRequests {
+		t.Errorf("Second request: expected status %d, got %d", http.StatusTooManyRequests, w2.Code)
+	}
+
+	// Verify the response body contains the expected error
+	var errResp ErrorResponse
+	if err := json.NewDecoder(w2.Body).Decode(&errResp); err != nil {
+		t.Fatalf("Failed to decode error response: %v", err)
+	}
+
+	if errResp.Error != "rate_limited" {
+		t.Errorf("Expected error code 'rate_limited', got %q", errResp.Error)
+	}
+
+	// Only the first request should have reached the handler
+	if handlerCallCount != 1 {
+		t.Errorf("Expected handler to be called 1 time, got %d", handlerCallCount)
+	}
+}
+
+func TestRateLimitMiddleware_DifferentIPsIndependent(t *testing.T) {
+	limiter := newIPRateLimiter(rate.Limit(0.001), 1) // burst of 1
+	middleware := rateLimitMiddleware(limiter)
+
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := middleware(testHandler)
+
+	// First IP uses its burst
+	req1 := httptest.NewRequest("POST", "/api/v1/auth/login", nil)
+	req1.RemoteAddr = "10.0.0.1:12345"
+	w1 := httptest.NewRecorder()
+	handler.ServeHTTP(w1, req1)
+
+	if w1.Code != http.StatusOK {
+		t.Errorf("IP1 first request: expected %d, got %d", http.StatusOK, w1.Code)
+	}
+
+	// First IP is now limited
+	req2 := httptest.NewRequest("POST", "/api/v1/auth/login", nil)
+	req2.RemoteAddr = "10.0.0.1:12345"
+	w2 := httptest.NewRecorder()
+	handler.ServeHTTP(w2, req2)
+
+	if w2.Code != http.StatusTooManyRequests {
+		t.Errorf("IP1 second request: expected %d, got %d", http.StatusTooManyRequests, w2.Code)
+	}
+
+	// Second IP should still work
+	req3 := httptest.NewRequest("POST", "/api/v1/auth/login", nil)
+	req3.RemoteAddr = "10.0.0.2:12345"
+	w3 := httptest.NewRecorder()
+	handler.ServeHTTP(w3, req3)
+
+	if w3.Code != http.StatusOK {
+		t.Errorf("IP2 first request: expected %d, got %d", http.StatusOK, w3.Code)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -63,6 +63,7 @@ import (
 	"time"
 
 	httpSwagger "github.com/swaggo/http-swagger"
+	"golang.org/x/time/rate"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -79,6 +80,7 @@ type Server struct {
 	v2Handler      *v2.Handler
 	authMiddleware *auth.Middleware
 	secretManager  *auth.SecretManager
+	stopCh         chan struct{} // signals background goroutines (e.g., rate limiter cleanup) to stop
 }
 
 // NewServer creates a new API server
@@ -110,18 +112,32 @@ func NewServer(port int, client client.Client, clientset kubernetes.Interface, n
 	}
 	authMw := auth.NewLazyMiddleware(getTokenGen)
 
+	// Set up user active status check: after JWT validation, verify the user account
+	// is still active by looking up the KrknUser CR. Uses a 1-minute TTL cache to
+	// avoid hitting the API server on every request.
+	userChecker := newK8sUserStatusChecker(client, namespace)
+	cachedChecker := auth.NewCachedUserStatusChecker(userChecker, 1*time.Minute)
+	authMw.SetUserStatusChecker(cachedChecker)
+
 	// Create v2 handler (WebSocket support only, REST reuses v1 handlers)
 	getTokenGenCtx := func(ctx context.Context) (*auth.TokenGenerator, error) {
 		return secretManager.GetTokenGenerator()
 	}
 	v2Handler := v2.NewHandler(client, namespace, handler, getTokenGenCtx) // handler implements AuthorizationChecker
 
+	// Create per-IP rate limiter for auth endpoints: 5 requests per minute, burst of 10
+	// This mitigates brute-force login attempts and registration abuse
+	authRateLimiter := newIPRateLimiter(rate.Every(12*time.Second), 10) // 5 per minute = 1 every 12s
+	stopCh := make(chan struct{})
+	authRateLimiter.startCleanup(10*time.Minute, 10*time.Minute, stopCh)
+	authRateLimit := rateLimitMiddleware(authRateLimiter)
+
 	mux := http.NewServeMux()
 
-	// Public authentication endpoints (no auth required)
-	mux.HandleFunc(AuthIsRegistered, handler.IsRegistered)
-	mux.HandleFunc(AuthRegister, handler.Register)
-	mux.HandleFunc(AuthLogin, handler.Login)
+	// Public authentication endpoints (no auth required, rate-limited)
+	mux.Handle(AuthIsRegistered, authRateLimit(http.HandlerFunc(handler.IsRegistered)))
+	mux.Handle(AuthRegister, authRateLimit(http.HandlerFunc(handler.Register)))
+	mux.Handle(AuthLogin, authRateLimit(http.HandlerFunc(handler.Login)))
 
 	// Authenticated endpoints - user and admin access
 	mux.Handle(HealthPath, authMw.RequireAuth(http.HandlerFunc(handler.HealthCheck)))
@@ -271,6 +287,7 @@ func NewServer(port int, client client.Client, clientset kubernetes.Interface, n
 		v2Handler:      v2Handler,
 		authMiddleware: authMw,
 		secretManager:  secretManager,
+		stopCh:         stopCh,
 	}
 }
 
@@ -323,8 +340,11 @@ startServer:
 	}
 }
 
-// Shutdown gracefully shuts down the API server
+// Shutdown gracefully shuts down the API server and stops background goroutines
 func (s *Server) Shutdown() error {
+	// Stop background goroutines (rate limiter cleanup, etc.)
+	close(s.stopCh)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	return s.server.Shutdown(ctx)

--- a/internal/api/user_status_checker.go
+++ b/internal/api/user_status_checker.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"fmt"
+
+	krknv1alpha1 "github.com/krkn-chaos/krkn-operator/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// k8sUserStatusChecker implements auth.UserStatusChecker by looking up KrknUser CRs
+// in the Kubernetes API server. It checks the Status.Active field to determine
+// whether a user account is still active.
+type k8sUserStatusChecker struct {
+	k8sClient client.Client
+	namespace string
+}
+
+// newK8sUserStatusChecker creates a new checker that looks up KrknUser CRs.
+//
+// Parameters:
+//   - k8sClient: the Kubernetes client used to read KrknUser CRs
+//   - namespace: the namespace where KrknUser CRs are stored
+//
+// Returns a k8sUserStatusChecker instance.
+func newK8sUserStatusChecker(k8sClient client.Client, namespace string) *k8sUserStatusChecker {
+	return &k8sUserStatusChecker{
+		k8sClient: k8sClient,
+		namespace: namespace,
+	}
+}
+
+// IsUserActive looks up the KrknUser CR for the given userID and returns
+// whether the account is active. The user is looked up by the sanitized
+// resource name (same as how user CRs are created during registration).
+//
+// Returns false if the user is not found (account may have been deleted).
+func (c *k8sUserStatusChecker) IsUserActive(ctx context.Context, userID string) (bool, error) {
+	// KrknUser CRs are named by sanitizing the email address
+	resourceName := sanitizeResourceName(userID)
+
+	var user krknv1alpha1.KrknUser
+	if err := c.k8sClient.Get(ctx, client.ObjectKey{
+		Name:      resourceName,
+		Namespace: c.namespace,
+	}, &user); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			// User CR not found -- treat as inactive (account deleted)
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to look up user %q: %w", userID, err)
+	}
+
+	return user.Status.Active, nil
+}

--- a/internal/api/v2/websocket/handler.go
+++ b/internal/api/v2/websocket/handler.go
@@ -74,18 +74,7 @@ func NewHandler(hub *Hub, k8sClient k8sclient.Client, namespace string, authz Au
 		upgrader: websocket.Upgrader{
 			ReadBufferSize:  1024,
 			WriteBufferSize: 1024,
-			CheckOrigin: func(r *http.Request) bool {
-				// SECURITY: Intentionally permissive (allows all origins)
-				// Rationale:
-				// 1. Authentication/authorization is enforced via JWT in Sec-WebSocket-Protocol
-				// 2. Invalid/missing JWT → connection refused at upgrade time
-				// 3. Valid JWT but insufficient permissions → filtered broadcasts (authz layer)
-				// 4. CORS-style origin checks don't prevent token theft attacks
-				// 5. Allows legitimate cross-origin use (e.g., separate frontend domain)
-				//
-				// If stricter origin validation is needed, configure an allowlist here.
-				return true
-			},
+			CheckOrigin:     checkWebSocketOriginV2,
 		},
 		pingInterval:   54 * time.Second,
 		pongWait:       60 * time.Second,

--- a/internal/api/v2/websocket/ws_origin.go
+++ b/internal/api/v2/websocket/ws_origin.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package websocket
+
+import (
+	"net/http"
+	"net/url"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// checkWebSocketOriginV2 validates the Origin header for WebSocket upgrade requests.
+// It applies a safe default policy:
+//   - Requests without an Origin header are allowed (non-browser clients like CLI tools).
+//   - Same-origin requests are allowed (Origin host matches request Host).
+//   - Cross-origin requests are rejected.
+//
+// This prevents cross-site WebSocket hijacking (CSWSH) attacks where a malicious
+// web page attempts to establish a WebSocket connection using the victim's credentials.
+func checkWebSocketOriginV2(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		// Non-browser clients (CLI, testing tools) don't send Origin
+		return true
+	}
+
+	// Parse the origin URL to extract the host
+	originURL, err := url.Parse(origin)
+	if err != nil {
+		logger := log.Log.WithName("websocket-v2-origin")
+		logger.Info("Rejected WebSocket connection: malformed Origin header",
+			"origin", origin,
+			"client_ip", r.RemoteAddr,
+		)
+		return false
+	}
+
+	// Allow same-origin requests
+	host := r.Host
+	if originURL.Host == host {
+		return true
+	}
+
+	logger := log.Log.WithName("websocket-v2-origin")
+	logger.Info("Rejected cross-origin WebSocket connection",
+		"origin", origin,
+		"host", host,
+		"client_ip", r.RemoteAddr,
+	)
+	return false
+}

--- a/internal/api/v2/websocket/ws_origin_test.go
+++ b/internal/api/v2/websocket/ws_origin_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package websocket
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCheckWebSocketOriginV2(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		origin   string
+		expected bool
+	}{
+		{
+			name:     "no origin header - allowed (non-browser client)",
+			host:     "localhost:8080",
+			origin:   "",
+			expected: true,
+		},
+		{
+			name:     "same origin - allowed",
+			host:     "localhost:8080",
+			origin:   "http://localhost:8080",
+			expected: true,
+		},
+		{
+			name:     "same origin HTTPS - allowed",
+			host:     "api.example.com",
+			origin:   "https://api.example.com",
+			expected: true,
+		},
+		{
+			name:     "cross origin - rejected",
+			host:     "api.example.com",
+			origin:   "https://evil.example.com",
+			expected: false,
+		},
+		{
+			name:     "cross origin different port - rejected",
+			host:     "localhost:8080",
+			origin:   "http://localhost:3000",
+			expected: false,
+		},
+		{
+			name:     "malformed origin - rejected",
+			host:     "localhost:8080",
+			origin:   "://not-a-valid-url",
+			expected: false,
+		},
+		{
+			name:     "subdomain mismatch - rejected",
+			host:     "api.example.com",
+			origin:   "https://other.api.example.com",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/ws", nil)
+			req.Host = tt.host
+			if tt.origin != "" {
+				req.Header.Set("Origin", tt.origin)
+			}
+
+			result := checkWebSocketOriginV2(req)
+			if result != tt.expected {
+				t.Errorf("checkWebSocketOriginV2() = %v, want %v (host=%q, origin=%q)",
+					result, tt.expected, tt.host, tt.origin)
+			}
+		})
+	}
+}

--- a/internal/api/ws_origin.go
+++ b/internal/api/ws_origin.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"net/http"
+	"net/url"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// checkWebSocketOrigin validates the Origin header for WebSocket upgrade requests.
+// It applies a safe default policy:
+//   - Requests without an Origin header are allowed (non-browser clients like CLI tools).
+//   - Same-origin requests are allowed (Origin host matches request Host).
+//   - Cross-origin requests are rejected.
+//
+// This prevents cross-site WebSocket hijacking (CSWSH) attacks where a malicious
+// web page attempts to establish a WebSocket connection to the API using the
+// victim's browser cookies/credentials.
+func checkWebSocketOrigin(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		// Non-browser clients (CLI, testing tools) don't send Origin
+		return true
+	}
+
+	// Parse the origin URL to extract the host
+	originURL, err := url.Parse(origin)
+	if err != nil {
+		logger := log.Log.WithName("websocket-origin")
+		logger.Info("Rejected WebSocket connection: malformed Origin header",
+			"origin", origin,
+			"client_ip", r.RemoteAddr,
+		)
+		return false
+	}
+
+	// Allow same-origin requests
+	host := r.Host
+	if originURL.Host == host {
+		return true
+	}
+
+	logger := log.Log.WithName("websocket-origin")
+	logger.Info("Rejected cross-origin WebSocket connection",
+		"origin", origin,
+		"host", host,
+		"client_ip", r.RemoteAddr,
+	)
+	return false
+}

--- a/internal/api/ws_origin_test.go
+++ b/internal/api/ws_origin_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCheckWebSocketOrigin(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		origin   string
+		expected bool
+	}{
+		{
+			name:     "no origin header - allowed (non-browser client)",
+			host:     "localhost:8080",
+			origin:   "",
+			expected: true,
+		},
+		{
+			name:     "same origin - allowed",
+			host:     "localhost:8080",
+			origin:   "http://localhost:8080",
+			expected: true,
+		},
+		{
+			name:     "same origin HTTPS - allowed",
+			host:     "api.example.com",
+			origin:   "https://api.example.com",
+			expected: true,
+		},
+		{
+			name:     "cross origin - rejected",
+			host:     "api.example.com",
+			origin:   "https://evil.example.com",
+			expected: false,
+		},
+		{
+			name:     "cross origin different port - rejected",
+			host:     "localhost:8080",
+			origin:   "http://localhost:3000",
+			expected: false,
+		},
+		{
+			name:     "malformed origin - rejected",
+			host:     "localhost:8080",
+			origin:   "://not-a-valid-url",
+			expected: false,
+		},
+		{
+			name:     "origin with path - allowed if host matches",
+			host:     "api.example.com",
+			origin:   "https://api.example.com/some/path",
+			expected: true,
+		},
+		{
+			name:     "subdomain mismatch - rejected",
+			host:     "api.example.com",
+			origin:   "https://other.api.example.com",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/ws", nil)
+			req.Host = tt.host
+			if tt.origin != "" {
+				req.Header.Set("Origin", tt.origin)
+			}
+
+			result := checkWebSocketOrigin(req)
+			if result != tt.expected {
+				t.Errorf("checkWebSocketOrigin() = %v, want %v (host=%q, origin=%q)",
+					result, tt.expected, tt.host, tt.origin)
+			}
+		})
+	}
+}

--- a/pkg/auth/middleware.go
+++ b/pkg/auth/middleware.go
@@ -22,6 +22,8 @@ import (
 	"context"
 	"net/http"
 	"strings"
+	"sync"
+	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -48,10 +50,84 @@ const (
 	RoleUser Role = "user"
 )
 
+// UserStatusChecker checks whether a user account is still active.
+// Implementations should look up the user (e.g., KrknUser CR) and return
+// whether the account is active. This interface decouples the auth middleware
+// from Kubernetes API types, keeping the pkg/auth package reusable.
+type UserStatusChecker interface {
+	// IsUserActive returns true if the user account identified by userID is active.
+	// It may use caching to avoid hitting the backing store on every request.
+	IsUserActive(ctx context.Context, userID string) (bool, error)
+}
+
+// userStatusCacheEntry stores a cached active status with its expiry time.
+type userStatusCacheEntry struct {
+	active  bool
+	expires time.Time
+}
+
+// CachedUserStatusChecker wraps a UserStatusChecker with a TTL cache to avoid
+// looking up user status on every authenticated request.
+type CachedUserStatusChecker struct {
+	checker UserStatusChecker
+	mu      sync.RWMutex
+	cache   map[string]userStatusCacheEntry
+	ttl     time.Duration
+}
+
+// NewCachedUserStatusChecker creates a new cached user status checker.
+//
+// Parameters:
+//   - checker: the underlying checker that performs the actual lookup
+//   - ttl: how long to cache each result (e.g., 1 minute)
+//
+// Returns a CachedUserStatusChecker instance.
+func NewCachedUserStatusChecker(checker UserStatusChecker, ttl time.Duration) *CachedUserStatusChecker {
+	return &CachedUserStatusChecker{
+		checker: checker,
+		cache:   make(map[string]userStatusCacheEntry),
+		ttl:     ttl,
+	}
+}
+
+// IsUserActive checks the cache first, then falls back to the underlying checker.
+func (c *CachedUserStatusChecker) IsUserActive(ctx context.Context, userID string) (bool, error) {
+	c.mu.RLock()
+	entry, exists := c.cache[userID]
+	c.mu.RUnlock()
+
+	if exists && time.Now().Before(entry.expires) {
+		return entry.active, nil
+	}
+
+	// Cache miss or expired -- look up the user
+	active, err := c.checker.IsUserActive(ctx, userID)
+	if err != nil {
+		return false, err
+	}
+
+	c.mu.Lock()
+	c.cache[userID] = userStatusCacheEntry{
+		active:  active,
+		expires: time.Now().Add(c.ttl),
+	}
+	c.mu.Unlock()
+
+	return active, nil
+}
+
+// InvalidateUser removes a user from the cache, forcing a fresh lookup on the next request.
+func (c *CachedUserStatusChecker) InvalidateUser(userID string) {
+	c.mu.Lock()
+	delete(c.cache, userID)
+	c.mu.Unlock()
+}
+
 // Middleware provides HTTP middleware for JWT authentication and authorization
 type Middleware struct {
-	tokenGen       *TokenGenerator
-	tokenGenLoader func() *TokenGenerator
+	tokenGen          *TokenGenerator
+	tokenGenLoader    func() *TokenGenerator
+	userStatusChecker UserStatusChecker
 }
 
 // NewMiddleware creates a new authentication middleware
@@ -76,6 +152,17 @@ func NewLazyMiddleware(tokenGenLoader func() *TokenGenerator) *Middleware {
 	return &Middleware{
 		tokenGenLoader: tokenGenLoader,
 	}
+}
+
+// SetUserStatusChecker sets the user status checker on the middleware.
+// When set, the middleware will verify that the user account is still active
+// after JWT validation succeeds. If the user is inactive, the request is
+// rejected with 401 Unauthorized.
+//
+// Parameters:
+//   - checker: the UserStatusChecker to use (typically a CachedUserStatusChecker)
+func (m *Middleware) SetUserStatusChecker(checker UserStatusChecker) {
+	m.userStatusChecker = checker
 }
 
 // RequireAuth is a middleware that requires a valid JWT token
@@ -133,6 +220,31 @@ func (m *Middleware) RequireAuth(next http.Handler) http.Handler {
 			)
 			http.Error(w, `{"error":"unauthorized","message":"Invalid or expired token"}`, http.StatusUnauthorized)
 			return
+		}
+
+		// Check if the user account is still active (if a checker is configured)
+		if m.userStatusChecker != nil {
+			active, err := m.userStatusChecker.IsUserActive(r.Context(), claims.UserID)
+			if err != nil {
+				logger.Error(err, "Failed to check user active status",
+					"path", r.URL.Path,
+					"method", r.Method,
+					"userId", claims.UserID,
+				)
+				// Fail open on transient errors would be a security risk.
+				// Fail closed: deny access if we cannot verify user status.
+				http.Error(w, `{"error":"internal_error","message":"Failed to verify user account status"}`, http.StatusInternalServerError)
+				return
+			}
+			if !active {
+				logger.Info("Authentication failed: user account is inactive",
+					"path", r.URL.Path,
+					"method", r.Method,
+					"userId", claims.UserID,
+				)
+				http.Error(w, `{"error":"unauthorized","message":"User account is inactive"}`, http.StatusUnauthorized)
+				return
+			}
 		}
 
 		logger.V(1).Info("Authentication successful",

--- a/pkg/auth/middleware_test.go
+++ b/pkg/auth/middleware_test.go
@@ -19,11 +19,30 @@ Assisted-by: Claude Sonnet 4.5 (claude-sonnet-4-5@20250929)
 package auth
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 )
+
+// mockUserStatusChecker is a test implementation of UserStatusChecker.
+type mockUserStatusChecker struct {
+	activeUsers map[string]bool // userID -> active
+	errUsers    map[string]error
+}
+
+func (m *mockUserStatusChecker) IsUserActive(_ context.Context, userID string) (bool, error) {
+	if err, ok := m.errUsers[userID]; ok {
+		return false, err
+	}
+	active, ok := m.activeUsers[userID]
+	if !ok {
+		return false, nil // user not found = inactive
+	}
+	return active, nil
+}
 
 func TestRequireAuth_ValidToken(t *testing.T) {
 	tg := NewTokenGenerator(
@@ -389,4 +408,264 @@ func TestIsAdminFromContext_NoAuth(t *testing.T) {
 	if IsAdmin(req.Context()) {
 		t.Error("Expected IsAdmin to return false when not authenticated")
 	}
+}
+
+func TestRequireAuth_InactiveUser(t *testing.T) {
+	tg := NewTokenGenerator(
+		[]byte("test-secret-key-at-least-32-bytes-long"),
+		24*time.Hour,
+		"krkn-operator",
+	)
+	middleware := NewMiddleware(tg)
+
+	// Set up a status checker that marks our user as inactive
+	checker := &mockUserStatusChecker{
+		activeUsers: map[string]bool{
+			"[email protected]": false,
+		},
+		errUsers: make(map[string]error),
+	}
+	middleware.SetUserStatusChecker(checker)
+
+	token, err := tg.GenerateToken("[email protected]", "user", "Inactive", "User", "Org")
+	if err != nil {
+		t.Fatalf("Failed to generate token: %v", err)
+	}
+
+	handlerCalled := false
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+	})
+
+	handler := middleware.RequireAuth(testHandler)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("Expected status %d, got %d", http.StatusUnauthorized, w.Code)
+	}
+	if handlerCalled {
+		t.Error("Handler should not be called for inactive user")
+	}
+}
+
+func TestRequireAuth_ActiveUser(t *testing.T) {
+	tg := NewTokenGenerator(
+		[]byte("test-secret-key-at-least-32-bytes-long"),
+		24*time.Hour,
+		"krkn-operator",
+	)
+	middleware := NewMiddleware(tg)
+
+	// Set up a status checker that marks our user as active
+	checker := &mockUserStatusChecker{
+		activeUsers: map[string]bool{
+			"[email protected]": true,
+		},
+		errUsers: make(map[string]error),
+	}
+	middleware.SetUserStatusChecker(checker)
+
+	token, err := tg.GenerateToken("[email protected]", "user", "Active", "User", "Org")
+	if err != nil {
+		t.Fatalf("Failed to generate token: %v", err)
+	}
+
+	handlerCalled := false
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := middleware.RequireAuth(testHandler)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
+	}
+	if !handlerCalled {
+		t.Error("Handler should be called for active user")
+	}
+}
+
+func TestRequireAuth_UserStatusCheckError(t *testing.T) {
+	tg := NewTokenGenerator(
+		[]byte("test-secret-key-at-least-32-bytes-long"),
+		24*time.Hour,
+		"krkn-operator",
+	)
+	middleware := NewMiddleware(tg)
+
+	// Set up a status checker that returns an error
+	checker := &mockUserStatusChecker{
+		activeUsers: make(map[string]bool),
+		errUsers: map[string]error{
+			"[email protected]": fmt.Errorf("k8s API unavailable"),
+		},
+	}
+	middleware.SetUserStatusChecker(checker)
+
+	token, err := tg.GenerateToken("[email protected]", "user", "Error", "User", "Org")
+	if err != nil {
+		t.Fatalf("Failed to generate token: %v", err)
+	}
+
+	handlerCalled := false
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+	})
+
+	handler := middleware.RequireAuth(testHandler)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	// Should fail closed (500 Internal Server Error)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("Expected status %d, got %d", http.StatusInternalServerError, w.Code)
+	}
+	if handlerCalled {
+		t.Error("Handler should not be called when status check fails")
+	}
+}
+
+func TestRequireAuth_NoStatusChecker(t *testing.T) {
+	// When no status checker is set, the middleware should allow requests
+	// (backward compatible behavior)
+	tg := NewTokenGenerator(
+		[]byte("test-secret-key-at-least-32-bytes-long"),
+		24*time.Hour,
+		"krkn-operator",
+	)
+	middleware := NewMiddleware(tg)
+	// Deliberately NOT setting a user status checker
+
+	token, err := tg.GenerateToken("[email protected]", "user", "Test", "User", "Org")
+	if err != nil {
+		t.Fatalf("Failed to generate token: %v", err)
+	}
+
+	handlerCalled := false
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := middleware.RequireAuth(testHandler)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
+	}
+	if !handlerCalled {
+		t.Error("Handler should be called when no status checker is configured")
+	}
+}
+
+func TestCachedUserStatusChecker(t *testing.T) {
+	callCount := 0
+	underlying := &mockUserStatusChecker{
+		activeUsers: map[string]bool{
+			"[email protected]": true,
+		},
+		errUsers: make(map[string]error),
+	}
+
+	// Wrap with a counting wrapper
+	countingChecker := &countingUserStatusChecker{
+		delegate:  underlying,
+		callCount: &callCount,
+	}
+
+	cached := NewCachedUserStatusChecker(countingChecker, 1*time.Minute)
+
+	ctx := context.Background()
+
+	// First call should hit the underlying checker
+	active, err := cached.IsUserActive(ctx, "[email protected]")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !active {
+		t.Error("Expected user to be active")
+	}
+	if callCount != 1 {
+		t.Errorf("Expected 1 call to underlying checker, got %d", callCount)
+	}
+
+	// Second call should use the cache
+	active, err = cached.IsUserActive(ctx, "[email protected]")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !active {
+		t.Error("Expected user to be active (from cache)")
+	}
+	if callCount != 1 {
+		t.Errorf("Expected still 1 call (cached), got %d", callCount)
+	}
+}
+
+func TestCachedUserStatusChecker_Invalidation(t *testing.T) {
+	underlying := &mockUserStatusChecker{
+		activeUsers: map[string]bool{
+			"[email protected]": true,
+		},
+		errUsers: make(map[string]error),
+	}
+
+	cached := NewCachedUserStatusChecker(underlying, 1*time.Minute)
+	ctx := context.Background()
+
+	// Warm the cache
+	active, err := cached.IsUserActive(ctx, "[email protected]")
+	if err != nil || !active {
+		t.Fatal("Expected active user")
+	}
+
+	// Deactivate the user in the underlying checker
+	underlying.activeUsers["[email protected]"] = false
+
+	// Cache still returns true
+	active, _ = cached.IsUserActive(ctx, "[email protected]")
+	if !active {
+		t.Error("Expected cached result to still be active")
+	}
+
+	// Invalidate the cache entry
+	cached.InvalidateUser("[email protected]")
+
+	// Now should see the updated value
+	active, _ = cached.IsUserActive(ctx, "[email protected]")
+	if active {
+		t.Error("Expected user to be inactive after cache invalidation")
+	}
+}
+
+// countingUserStatusChecker wraps a UserStatusChecker and counts calls.
+type countingUserStatusChecker struct {
+	delegate  UserStatusChecker
+	callCount *int
+}
+
+func (c *countingUserStatusChecker) IsUserActive(ctx context.Context, userID string) (bool, error) {
+	*c.callCount++
+	return c.delegate.IsUserActive(ctx, userID)
 }


### PR DESCRIPTION
## Summary

- **Rate limiting on auth endpoints**: Added per-IP rate limiting (5 req/min, burst 10) to `/auth/login`, `/auth/register`, and `/auth/is-registered` endpoints using `golang.org/x/time/rate`. Includes automatic cleanup of stale entries every 10 minutes to prevent memory leaks from unique IPs.

- **User active status check in auth middleware**: After JWT validation succeeds, the middleware now verifies the user account is still active by looking up the KrknUser CR's `Status.Active` field. Uses a `CachedUserStatusChecker` with 1-minute TTL to avoid hitting the Kubernetes API server on every request. Fails closed (denies access) if the lookup errors out.

- **WebSocket origin validation**: Replaced permissive `CheckOrigin: func(r) { return true }` in both v1 (`handlers.go`) and v2 (`websocket/handler.go`) WebSocket upgraders with same-origin validation that allows non-browser clients (no Origin header) and same-host requests while rejecting cross-origin connections. Prevents cross-site WebSocket hijacking (CSWSH) attacks.

## Test plan

- [x] Rate limiter unit tests: verify blocking after burst exhaustion, independent limits per IP, stale entry cleanup
- [x] Rate limit middleware tests: verify 429 response on excess, passthrough under limit, per-IP independence
- [x] WebSocket origin tests (v1 and v2): verify same-origin allowed, cross-origin rejected, no-origin allowed, malformed origin rejected
- [x] User active status tests: verify inactive users get 401, active users pass through, lookup errors fail closed (500), backward compat when no checker configured
- [x] Cached checker tests: verify caching behavior and invalidation
- [x] All existing tests pass (`go test ./internal/api/... ./pkg/auth/...`)
- [x] Full build passes (`go build ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)