### PR TITLE
chore: code quality cleanup (regex, dedup, dead code, logs)

### DIFF
--- a/internal/api/auth_handlers.go
+++ b/internal/api/auth_handlers.go
@@ -486,7 +486,7 @@ func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get token generator from SecretManager
-	tokenGen, err := h.getTokenGenerator(ctx)
+	tokenGen, err := h.getTokenGenerator()
 	if err != nil {
 		logger.Error(err, "Failed to get token generator")
 		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{

--- a/internal/api/files_handlers.go
+++ b/internal/api/files_handlers.go
@@ -870,19 +870,23 @@ func (h *Handler) isFileOwnerOrAdmin(ctx context.Context, configMap *corev1.Conf
 
 // buildFileResponse builds a FileResponse from a ConfigMap
 func buildFileResponse(configMap *corev1.ConfigMap) files.FileResponse {
-	// Extract content and studioLayout from data
-	content := ""
-	studioLayout := ""
-	for k, v := range configMap.Data {
-		switch k {
-		case "studioLayout.json":
-			studioLayout = v
-		default:
-			content = v
+	logicalName := configMap.Annotations[files.WorkflowNameAnnotation]
+
+	// Access studioLayout by its well-known key.
+	studioLayout := configMap.Data["studioLayout.json"]
+
+	// Look up the content by the logical filename stored in the annotation.
+	// If the annotation is missing or the key does not exist in Data (e.g. legacy
+	// ConfigMaps), fall back to the first Data key that is not studioLayout.json.
+	content, ok := configMap.Data[logicalName]
+	if !ok || logicalName == "" {
+		for k, v := range configMap.Data {
+			if k != "studioLayout.json" {
+				content = v
+				break
+			}
 		}
 	}
-
-	logicalName := configMap.Annotations[files.WorkflowNameAnnotation]
 
 	return files.FileResponse{
 		FileID:         files.ExtractFileIDFromLabels(configMap.Labels),
@@ -985,30 +989,32 @@ func isValidConfigMapKey(key string) bool {
 	return true
 }
 
-func validateCreateFileRequest(ctx context.Context, k8sClient client.Client, req *files.CreateFileRequest, namespace string, isAdmin bool, userID string) error {
+// validateFileFields validates the common fields shared by create and update file requests:
+// fileName, content, groups, availableToAll, and group existence.
+func validateFileFields(ctx context.Context, k8sClient client.Client, fileName, content string, groups []string, availableToAll bool, namespace string, isAdmin bool, userID string) error {
 	// Validate file name
-	if req.FileName == "" {
+	if fileName == "" {
 		return fmt.Errorf("fileName is required")
 	}
 
 	// Validate fileName is a valid ConfigMap key (alphanumeric, -, _, .)
 	// ConfigMap keys must match: [a-zA-Z0-9._-]+
-	if !isValidConfigMapKey(req.FileName) {
+	if !isValidConfigMapKey(fileName) {
 		return fmt.Errorf("fileName contains invalid characters (allowed: alphanumeric, -, _, .)")
 	}
 
 	// Validate content is not empty
-	if req.Content == "" {
+	if content == "" {
 		return fmt.Errorf("content is required")
 	}
 
 	// Validate content is valid JSON or YAML
-	if err := files.ValidateFileContent(req.Content); err != nil {
+	if err := files.ValidateFileContent(content); err != nil {
 		return err
 	}
 
 	// Validate file groups (max 1, mutually exclusive with availableToAll)
-	if err := files.ValidateFileGroups(req.Groups, req.AvailableToAll); err != nil {
+	if err := files.ValidateFileGroups(groups, availableToAll); err != nil {
 		return err
 	}
 
@@ -1025,12 +1031,12 @@ func validateCreateFileRequest(ctx context.Context, k8sClient client.Client, req
 	}
 
 	// Validate user permissions (non-admin can assign to their own group or make public)
-	if err := files.ValidateUserFilePermissions(isAdmin, req.Groups, req.AvailableToAll, userGroups); err != nil {
+	if err := files.ValidateUserFilePermissions(isAdmin, groups, availableToAll, userGroups); err != nil {
 		return err
 	}
 
 	// Validate groups exist
-	for _, groupName := range req.Groups {
+	for _, groupName := range groups {
 		var group krknv1alpha1.KrknUserGroup
 		err := k8sClient.Get(ctx, types.NamespacedName{
 			Name:      groupName,
@@ -1047,66 +1053,13 @@ func validateCreateFileRequest(ctx context.Context, k8sClient client.Client, req
 	return nil
 }
 
+func validateCreateFileRequest(ctx context.Context, k8sClient client.Client, req *files.CreateFileRequest, namespace string, isAdmin bool, userID string) error {
+	return validateFileFields(ctx, k8sClient, req.FileName, req.Content, req.Groups, req.AvailableToAll, namespace, isAdmin, userID)
+}
+
 // validateUpdateFileRequest validates an UpdateFileRequest
 func validateUpdateFileRequest(ctx context.Context, k8sClient client.Client, req *files.UpdateFileRequest, namespace string, isAdmin bool, userID string) error {
-	// Validate file name
-	if req.FileName == "" {
-		return fmt.Errorf("fileName is required")
-	}
-
-	// Validate fileName is a valid ConfigMap key (alphanumeric, -, _, .)
-	if !isValidConfigMapKey(req.FileName) {
-		return fmt.Errorf("fileName contains invalid characters (allowed: alphanumeric, -, _, .)")
-	}
-
-	// Validate content is not empty
-	if req.Content == "" {
-		return fmt.Errorf("content is required")
-	}
-
-	// Validate content is valid JSON or YAML
-	if err := files.ValidateFileContent(req.Content); err != nil {
-		return err
-	}
-
-	// Validate file groups (max 1, mutually exclusive with availableToAll)
-	if err := files.ValidateFileGroups(req.Groups, req.AvailableToAll); err != nil {
-		return err
-	}
-
-	// Get user's groups for permission validation
-	userGroupsObjs, err := groupauth.GetUserGroups(ctx, k8sClient, userID, namespace)
-	if err != nil {
-		return fmt.Errorf("failed to get user groups: %w", err)
-	}
-
-	// Extract group names
-	userGroups := make([]string, len(userGroupsObjs))
-	for i, ug := range userGroupsObjs {
-		userGroups[i] = ug.Name
-	}
-
-	// Validate user permissions (non-admin can assign to their own group or make public)
-	if err := files.ValidateUserFilePermissions(isAdmin, req.Groups, req.AvailableToAll, userGroups); err != nil {
-		return err
-	}
-
-	// Validate groups exist
-	for _, groupName := range req.Groups {
-		var group krknv1alpha1.KrknUserGroup
-		err := k8sClient.Get(ctx, types.NamespacedName{
-			Name:      groupName,
-			Namespace: namespace,
-		}, &group)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				return fmt.Errorf("group '%s' does not exist", groupName)
-			}
-			return fmt.Errorf("failed to validate group '%s': %w", groupName, err)
-		}
-	}
-
-	return nil
+	return validateFileFields(ctx, k8sClient, req.FileName, req.Content, req.Groups, req.AvailableToAll, namespace, isAdmin, userID)
 }
 
 // ensureFileTypeExists creates a KrknFileType if it doesn't exist (auto-creation pattern).

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -58,6 +58,12 @@ import (
 	pb "github.com/krkn-chaos/krkn-operator/proto/dataprovider"
 )
 
+// Package-level compiled regexes for sanitization functions.
+var (
+	resourceNameRegex = regexp.MustCompile(`[^a-z0-9-]`)
+	runNameLabelRegex = regexp.MustCompile(`[^a-zA-Z0-9._-]`)
+)
+
 // sanitizeResourceName converts an email or identifier into a valid Kubernetes resource name.
 // Kubernetes resource names must follow RFC 1123 subdomain rules:
 // - Contain only lowercase alphanumeric characters, '-' or '.'
@@ -80,8 +86,7 @@ func sanitizeResourceName(name string) string {
 	sanitized = strings.ReplaceAll(sanitized, ".", "-")
 
 	// Replace any other invalid characters with -
-	reg := regexp.MustCompile(`[^a-z0-9-]`)
-	sanitized = reg.ReplaceAllString(sanitized, "-")
+	sanitized = resourceNameRegex.ReplaceAllString(sanitized, "-")
 
 	// Remove leading/trailing dashes
 	sanitized = strings.Trim(sanitized, "-")
@@ -98,8 +103,7 @@ func sanitizeResourceName(name string) string {
 // sanitizeRunNameLabel converts a customRunName into a valid Kubernetes label value
 // (max 63 chars, alphanumeric + dash/dot/underscore, must start and end with alphanumeric).
 func sanitizeRunNameLabel(name string) string {
-	reg := regexp.MustCompile(`[^a-zA-Z0-9._-]`)
-	sanitized := reg.ReplaceAllString(name, "-")
+	sanitized := runNameLabelRegex.ReplaceAllString(name, "-")
 	sanitized = strings.Trim(sanitized, "-_.")
 	if len(sanitized) > 63 {
 		sanitized = sanitized[:63]
@@ -133,7 +137,7 @@ func NewHandler(client client.Client, clientset kubernetes.Interface, namespace 
 
 // getTokenGenerator creates a TokenGenerator for JWT validation (used for WebSocket auth)
 // It uses the same JWT secret as the HTTP middleware via SecretManager
-func (h *Handler) getTokenGenerator(ctx context.Context) (*auth.TokenGenerator, error) {
+func (h *Handler) getTokenGenerator() (*auth.TokenGenerator, error) {
 	tokenGen, err := h.secretManager.GetTokenGenerator()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get token generator from SecretManager: %w", err)
@@ -465,7 +469,7 @@ func (h *Handler) PostTarget(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Return 102 Processing with the UUID
+	// Return 202 Accepted with the UUID
 	response := map[string]string{
 		"uuid": newUUID,
 	}
@@ -856,7 +860,9 @@ func filterScenariosByIsAScenario(ctx context.Context, scenarioProvider provider
 			return nil
 		})
 	}
-	_ = g.Wait()
+	if err := g.Wait(); err != nil {
+		log.FromContext(ctx).Error(err, "error during scenario filtering")
+	}
 
 	scenarios := make([]ScenarioTag, 0, len(tags))
 	for _, r := range results {
@@ -1700,7 +1706,7 @@ func isWebSocketDisconnectError(err error) bool {
 func (h *Handler) GetScenarioRunLogs(w http.ResponseWriter, r *http.Request) {
 	logger := log.Log.WithName("websocket-logs")
 
-	logger.Info("🔌 WebSocket connection request received",
+	logger.Info("WebSocket connection request received",
 		"path", r.URL.Path,
 		"client_ip", r.RemoteAddr,
 		"user_agent", r.Header.Get("User-Agent"))
@@ -1709,13 +1715,13 @@ func (h *Handler) GetScenarioRunLogs(w http.ResponseWriter, r *http.Request) {
 	// Frontend sends: new WebSocket(url, `access_token.${jwt_token}`)
 	// Format: "access_token.<jwt_token>"
 	protocols := r.Header.Get("Sec-WebSocket-Protocol")
-	logger.V(1).Info("📋 Received WebSocket headers",
+	logger.V(1).Info("Received WebSocket headers",
 		"Sec-WebSocket-Protocol", protocols,
 		"Sec-WebSocket-Version", r.Header.Get("Sec-WebSocket-Version"),
 		"Sec-WebSocket-Key", r.Header.Get("Sec-WebSocket-Key"))
 
 	if protocols == "" {
-		logger.Info("❌ WebSocket authentication failed: missing Sec-WebSocket-Protocol header",
+		logger.Info("WebSocket authentication failed: missing Sec-WebSocket-Protocol header",
 			"path", r.URL.Path,
 			"client_ip", r.RemoteAddr,
 			"headers", r.Header)
@@ -1725,12 +1731,12 @@ func (h *Handler) GetScenarioRunLogs(w http.ResponseWriter, r *http.Request) {
 
 	// Parse protocol: split on first '.' to separate prefix from token
 	// Example: "access_token.eyJhbGc..." → ["access_token", "eyJhbGc..."]
-	logger.V(1).Info("🔍 Parsing Sec-WebSocket-Protocol",
+	logger.V(1).Info("Parsing Sec-WebSocket-Protocol",
 		"raw_protocol", protocols,
 		"protocol_length", len(protocols))
 
 	protocolParts := strings.SplitN(protocols, ".", 2)
-	logger.V(1).Info("🔍 Protocol parts after split",
+	logger.V(1).Info("Protocol parts after split",
 		"parts_count", len(protocolParts),
 		"part_0", func() string {
 			if len(protocolParts) > 0 {
@@ -1746,7 +1752,7 @@ func (h *Handler) GetScenarioRunLogs(w http.ResponseWriter, r *http.Request) {
 		}())
 
 	if len(protocolParts) != 2 || protocolParts[0] != "access_token" {
-		logger.Info("❌ WebSocket authentication failed: invalid protocol format",
+		logger.Info("WebSocket authentication failed: invalid protocol format",
 			"path", r.URL.Path,
 			"protocol", protocols,
 			"parts_count", len(protocolParts),
@@ -1758,7 +1764,7 @@ func (h *Handler) GetScenarioRunLogs(w http.ResponseWriter, r *http.Request) {
 
 	token := protocolParts[1]
 	if token == "" {
-		logger.Info("❌ WebSocket authentication failed: empty token in subprotocol",
+		logger.Info("WebSocket authentication failed: empty token in subprotocol",
 			"path", r.URL.Path,
 			"client_ip", r.RemoteAddr)
 		http.Error(w, "Unauthorized: Missing authentication token", http.StatusUnauthorized)
@@ -1773,23 +1779,23 @@ func (h *Handler) GetScenarioRunLogs(w http.ResponseWriter, r *http.Request) {
 		return token[:10] + "..." + token[len(token)-10:]
 	}()
 
-	logger.Info("🔑 JWT token extracted from subprotocol",
+	logger.Info("JWT token extracted from subprotocol",
 		"token_length", len(token),
 		"token_preview", maskedToken)
 
 	// Get TokenGenerator and validate token
-	logger.V(1).Info("🔐 Getting TokenGenerator for validation")
-	tokenGen, err := h.getTokenGenerator(r.Context())
+	logger.V(1).Info("Getting TokenGenerator for validation")
+	tokenGen, err := h.getTokenGenerator()
 	if err != nil {
-		logger.Error(err, "❌ Failed to get TokenGenerator for WebSocket auth")
+		logger.Error(err, "Failed to get TokenGenerator for WebSocket auth")
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
 
-	logger.Info("🔐 Validating JWT token")
+	logger.Info("Validating JWT token")
 	claims, err := tokenGen.ValidateToken(token)
 	if err != nil {
-		logger.Info("❌ WebSocket authentication failed: invalid token",
+		logger.Info("WebSocket authentication failed: invalid token",
 			"path", r.URL.Path,
 			"error", err.Error(),
 			"token_preview", maskedToken,
@@ -1798,7 +1804,7 @@ func (h *Handler) GetScenarioRunLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	logger.Info("✅ WebSocket authentication successful",
+	logger.Info("WebSocket authentication successful",
 		"userId", claims.UserID,
 		"role", claims.Role,
 		"path", r.URL.Path,
@@ -1808,14 +1814,14 @@ func (h *Handler) GetScenarioRunLogs(w http.ResponseWriter, r *http.Request) {
 	// WebSocket spec requires server to respond with one of the client's requested subprotocols
 	// Client sent: "access_token.<jwt_token>"
 	// Server must respond with the SAME value (not just "access_token")
-	logger.Info("⬆️ Upgrading connection to WebSocket",
+	logger.Info("Upgrading connection to WebSocket",
 		"response_protocol", protocols)
 
 	conn, err := upgrader.Upgrade(w, r, http.Header{
 		"Sec-WebSocket-Protocol": []string{protocols}, // Echo back the full protocol
 	})
 	if err != nil {
-		logger.Error(err, "❌ WebSocket upgrade failed",
+		logger.Error(err, "WebSocket upgrade failed",
 			"url", r.URL.String(),
 			"headers", r.Header,
 			"client_ip", r.RemoteAddr)
@@ -1823,7 +1829,7 @@ func (h *Handler) GetScenarioRunLogs(w http.ResponseWriter, r *http.Request) {
 	}
 	defer conn.Close()
 
-	logger.Info("✅ WebSocket connection established",
+	logger.Info("WebSocket connection established",
 		"userId", claims.UserID,
 		"client_ip", r.RemoteAddr)
 

--- a/internal/api/provider_config_handlers.go
+++ b/internal/api/provider_config_handlers.go
@@ -140,7 +140,7 @@ func (h *Handler) UpdateProviderConfigValues(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	logger.Info("📥 Received provider config update request",
+	logger.Info("Received provider config update request",
 		"uuid", uuid,
 		"provider_name", req.ProviderName,
 		"values_count", len(req.Values),
@@ -207,7 +207,7 @@ func (h *Handler) UpdateProviderConfigValues(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	logger.Info("📋 Provider config data found",
+	logger.Info("Provider config data found",
 		"provider_name", req.ProviderName,
 		"configmap_name", providerData.ConfigMap,
 		"namespace", providerData.Namespace,
@@ -215,16 +215,16 @@ func (h *Handler) UpdateProviderConfigValues(w http.ResponseWriter, r *http.Requ
 
 	// Validate all values against schema
 	var updatedFields []string
-	logger.V(1).Info("🔍 Starting validation of values against schema",
+	logger.V(1).Info("Starting validation of values against schema",
 		"schema_json", providerData.ConfigSchema)
 
 	for key, value := range req.Values {
-		logger.V(1).Info("🔍 Validating field",
+		logger.V(1).Info("Validating field",
 			"key", key,
 			"value", value)
 
 		if err := ValidateValueAgainstSchema(key, value, providerData.ConfigSchema); err != nil {
-			logger.Error(err, "❌ Validation failed",
+			logger.Error(err, "Validation failed",
 				"key", key,
 				"value", value,
 				"schema", providerData.ConfigSchema)
@@ -244,7 +244,7 @@ func (h *Handler) UpdateProviderConfigValues(w http.ResponseWriter, r *http.Requ
 			})
 			return
 		}
-		logger.V(1).Info("✅ Field validated successfully", "key", key)
+		logger.V(1).Info("Field validated successfully", "key", key)
 		updatedFields = append(updatedFields, key)
 	}
 
@@ -323,7 +323,7 @@ func (h *Handler) UpdateProviderConfigValues(w http.ResponseWriter, r *http.Requ
 		// Don't fail the request, just log the error
 		// The ConfigMap was updated successfully
 	} else {
-		logger.Info("✅ Deleted KrknOperatorTargetProviderConfig after successful ConfigMap update",
+		logger.Info("Deleted KrknOperatorTargetProviderConfig after successful ConfigMap update",
 			"uuid", uuid)
 	}
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -293,12 +293,12 @@ func (s *Server) Start(ctx context.Context) error {
 			return ctx.Err()
 
 		case <-timeout:
-			logger.Error(nil, "❌ Timeout waiting for JWT secret to be ready")
+			logger.Error(nil, "Timeout waiting for JWT secret to be ready")
 			return fmt.Errorf("timeout waiting for JWT secret to be ready after 2 minutes")
 
 		case <-ticker.C:
 			if s.secretManager.IsReady() {
-				logger.Info("✅ JWT secret ready, starting HTTP server", "addr", s.server.Addr)
+				logger.Info("JWT secret ready, starting HTTP server", "addr", s.server.Addr)
 				goto startServer
 			}
 			logger.V(1).Info("Waiting for JWT secret to be ready...")
@@ -313,7 +313,7 @@ startServer:
 		}
 	}()
 
-	logger.Info("🚀 REST API server started and accepting connections", "addr", s.server.Addr)
+	logger.Info("REST API server started and accepting connections", "addr", s.server.Addr)
 
 	select {
 	case err := <-errChan:

--- a/internal/api/targets_crud.go
+++ b/internal/api/targets_crud.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,8 +49,8 @@ func (h *Handler) fetchTarget(ctx context.Context, targetUUID string) (*krknv1al
 	}, &target)
 
 	if err != nil {
-		if client.IgnoreNotFound(err) == nil {
-			return nil, fmt.Errorf("target with UUID '%s' not found", targetUUID)
+		if apierrors.IsNotFound(err) {
+			return nil, err
 		}
 		return nil, fmt.Errorf("failed to get target: %w", err)
 	}
@@ -547,7 +548,7 @@ func (h *Handler) TargetsCRUDRouter(w http.ResponseWriter, r *http.Request) {
 // writeTargetFetchError writes appropriate error response based on the fetch error.
 func (h *Handler) writeTargetFetchError(w http.ResponseWriter, err error) {
 	statusCode := http.StatusInternalServerError
-	if strings.Contains(err.Error(), "not found") {
+	if apierrors.IsNotFound(err) {
 		statusCode = http.StatusNotFound
 	}
 	writeJSONError(w, statusCode, ErrorResponse{

--- a/pkg/groupauth/labels.go
+++ b/pkg/groupauth/labels.go
@@ -23,6 +23,9 @@ import (
 	"strings"
 )
 
+// groupNameRegex matches characters that are NOT valid in Kubernetes label names.
+var groupNameRegex = regexp.MustCompile(`[^a-zA-Z0-9\-_.]+`)
+
 // GroupLabelKey returns the label key for a group name
 // Example: "dev-team" -> "group.krkn.krkn-chaos.dev/dev-team"
 func GroupLabelKey(groupName string) string {
@@ -52,7 +55,7 @@ func ExtractGroupNamesFromLabels(labels map[string]string) []string {
 // Note: Does NOT truncate. Caller must validate length (63 char limit for K8s labels).
 func SanitizeGroupName(groupName string) string {
 	// Replace invalid characters with hyphens
-	sanitized := regexp.MustCompile(`[^a-zA-Z0-9\-_.]+`).ReplaceAllString(groupName, "-")
+	sanitized := groupNameRegex.ReplaceAllString(groupName, "-")
 
 	// Trim leading/trailing hyphens, underscores, and dots
 	sanitized = strings.Trim(sanitized, "-_.")


### PR DESCRIPTION
## Summary
- Move per-call `regexp.MustCompile` to package-level vars in `handlers.go` and `groupauth/labels.go` for better performance
- Extract duplicate validation logic from `validateCreateFileRequest` and `validateUpdateFileRequest` into shared `validateFileFields` helper
- Remove unused `ctx` parameter from `getTokenGenerator` and update all callers
- Fix non-deterministic map iteration in `buildFileResponse` by using direct key lookup with fallback for legacy ConfigMaps
- Replace string-based error matching (`strings.Contains(err.Error(), "not found")`) in `writeTargetFetchError` with `apierrors.IsNotFound(err)` for type-safe Kubernetes error detection
- Remove emoji characters from all log messages across `handlers.go`, `provider_config_handlers.go`, and `server.go`
- Fix stale comment: "Return 102 Processing" -> "Return 202 Accepted"
- Handle errgroup error from `g.Wait()` instead of discarding it

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/api/...` passes (all tests green)
- [x] `go test ./pkg/groupauth/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)