### PR TITLE
feat(api): add config endpoints for ScenarioRun and GraphRun

### DIFF
--- a/internal/api/graphrun_handlers.go
+++ b/internal/api/graphrun_handlers.go
@@ -707,6 +707,16 @@ func (h *Handler) GraphRunsRouter(w http.ResponseWriter, r *http.Request) {
 
 	// Nested endpoints: /api/v1/graphruns/:name
 	if strings.HasPrefix(path, GraphRunsPath+"/") {
+		// Check for /{graphRunName}/config pattern (GET only - graph run config)
+		if strings.HasSuffix(path, "/config") {
+			if r.Method == http.MethodGet {
+				h.GetGraphRunConfig(w, r)
+			} else {
+				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			}
+			return
+		}
+
 		switch r.Method {
 		case http.MethodGet:
 			h.GetGraphRun(w, r)

--- a/internal/api/graphrun_handlers.go
+++ b/internal/api/graphrun_handlers.go
@@ -686,11 +686,12 @@ func convertNodeStatusesWithScores(nodeStatuses []krknv1alpha1.NodeStatus, graph
 
 // GraphRunsRouter routes GraphRun HTTP requests to appropriate handlers
 func (h *Handler) GraphRunsRouter(w http.ResponseWriter, r *http.Request) {
-	path := r.URL.Path
+	path := strings.Replace(r.URL.Path, "/api/v2/", "/api/v1/", 1)
 
-	// Normalize v2 paths to v1 for backward-compatible routing
-	// v2 REST endpoints reuse v1 handler logic (same behavior, different path prefix)
-	path = strings.Replace(path, "/api/v2/", "/api/v1/", 1)
+	// Normalize v2 paths to v1 so downstream handlers can parse with v1 prefixes
+	if path != r.URL.Path {
+		r.URL.Path = path
+	}
 
 	// Root endpoint: /api/v1/graphruns (or /api/v2/graphruns normalized)
 	if path == GraphRunsPath {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -2661,6 +2661,16 @@ func (h *Handler) ScenariosRunRouter(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		// Check for /{scenarioRunName}/config pattern (GET only - scenario run config)
+		if strings.HasSuffix(path, "/config") {
+			if r.Method == http.MethodGet {
+				h.GetScenarioRunConfig(w, r)
+			} else {
+				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			}
+			return
+		}
+
 		// Check for /jobs/{jobID} pattern (GET or DELETE single job)
 		if strings.HasPrefix(path, ScenariosRunJobsPath+"/") {
 			switch r.Method {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -2627,11 +2627,12 @@ func (h *Handler) GetSingleJob(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) ScenariosRunRouter(w http.ResponseWriter, r *http.Request) {
-	path := r.URL.Path
+	path := strings.Replace(r.URL.Path, "/api/v2/", "/api/v1/", 1)
 
-	// Normalize v2 paths to v1 for backward-compatible routing
-	// v2 REST endpoints reuse v1 handler logic (same behavior, different path prefix)
-	path = strings.Replace(path, "/api/v2/", "/api/v1/", 1)
+	// Normalize v2 paths to v1 so downstream handlers can parse with v1 prefixes
+	if path != r.URL.Path {
+		r.URL.Path = path
+	}
 
 	// Root endpoint: /api/v1/scenarios/run (or /api/v2/scenarios/run normalized)
 	if path == ScenariosRunPath {

--- a/internal/api/run_config_handlers.go
+++ b/internal/api/run_config_handlers.go
@@ -1,0 +1,246 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	krknv1alpha1 "github.com/krkn-chaos/krkn-operator/api/v1alpha1"
+	"github.com/krkn-chaos/krkn-operator/pkg/auth"
+	"github.com/krkn-chaos/krkn-operator/pkg/groupauth"
+)
+
+// GetScenarioRunConfig handles GET /api/v1/scenarios/run/{scenarioRunName}/config
+// Returns the configuration payload for a scenario run, ready for replay via POST /scenarios/run
+//
+// @Summary Get scenario run configuration
+// @Description Retrieve scenario configuration directly by KrknScenarioRun CR name
+// @Tags scenarios
+// @Produce json
+// @Param scenarioRunName path string true "KrknScenarioRun CR name"
+// @Success 200 {object} ScenarioRunRequest "Scenario configuration"
+// @Failure 400 {object} ErrorResponse "Missing scenario run name"
+// @Failure 401 {object} ErrorResponse "User authentication required"
+// @Failure 403 {object} ErrorResponse "Insufficient permissions"
+// @Failure 404 {object} ErrorResponse "ScenarioRun not found"
+// @Failure 500 {object} ErrorResponse "Internal server error"
+// @Security BearerAuth
+// @Router /scenarios/run/{scenarioRunName}/config [get]
+func (h *Handler) GetScenarioRunConfig(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	logger := log.FromContext(ctx)
+
+	// Extract scenarioRunName from URL path
+	// Path format: /api/v1/scenarios/run/{scenarioRunName}/config
+	trimmed := strings.TrimPrefix(r.URL.Path, ScenariosRunPath+"/")
+	scenarioRunName := strings.TrimSuffix(trimmed, "/config")
+	if scenarioRunName == "" {
+		writeJSONError(w, http.StatusBadRequest, ErrorResponse{
+			Error:   "bad_request",
+			Message: "Scenario run name is required",
+		})
+		return
+	}
+
+	logger.V(1).Info("Scenario run config request received", "scenarioRunName", scenarioRunName)
+
+	// Fetch KrknScenarioRun CR
+	scenarioRun, err := h.getScenarioRun(ctx, scenarioRunName)
+	if err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			writeJSONError(w, http.StatusNotFound, ErrorResponse{
+				Error:   "not_found",
+				Message: fmt.Sprintf("ScenarioRun '%s' not found", scenarioRunName),
+			})
+		} else {
+			logger.Error(err, "Failed to get ScenarioRun", "scenarioRunName", scenarioRunName)
+			writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
+				Error:   "internal_error",
+				Message: "Failed to retrieve ScenarioRun",
+			})
+		}
+		return
+	}
+
+	// Validate RBAC permissions
+	claims := auth.GetClaimsFromContext(ctx)
+	if claims == nil {
+		writeJSONError(w, http.StatusUnauthorized, ErrorResponse{
+			Error:   "unauthorized",
+			Message: "User authentication required",
+		})
+		return
+	}
+
+	if !auth.IsAdmin(ctx) {
+		targetRequest := &krknv1alpha1.KrknTargetRequest{}
+		if err := h.client.Get(ctx, types.NamespacedName{
+			Name:      scenarioRun.Spec.TargetRequestID,
+			Namespace: h.namespace,
+		}, targetRequest); err != nil {
+			logger.Error(err, "Failed to fetch target request", "targetRequestId", scenarioRun.Spec.TargetRequestID)
+			writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
+				Error:   "internal_error",
+				Message: "Failed to validate permissions",
+			})
+			return
+		}
+
+		if err := groupauth.ValidateScenarioRunAccess(
+			ctx,
+			h.client,
+			claims.UserID,
+			h.namespace,
+			scenarioRun.Spec.TargetClusters,
+			targetRequest,
+		); err != nil {
+			logger.Info("User lacks permission to view scenario run config",
+				"userID", claims.UserID,
+				"error", err.Error(),
+			)
+			writeJSONError(w, http.StatusForbidden, ErrorResponse{
+				Error:   "forbidden",
+				Message: err.Error(),
+			})
+			return
+		}
+	}
+
+	// Reconstruct payload (same as replay)
+	payload, err := h.reconstructScenarioRunPayload(ctx, scenarioRun)
+	if err != nil {
+		logger.Error(err, "Failed to reconstruct scenario payload", "scenarioRunName", scenarioRunName)
+		writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
+			Error:   "internal_error",
+			Message: "Failed to reconstruct scenario configuration",
+		})
+		return
+	}
+
+	logger.Info("Scenario run config retrieved successfully",
+		"scenarioRunName", scenarioRunName,
+		"userID", claims.UserID)
+
+	writeJSON(w, http.StatusOK, payload)
+}
+
+// GetGraphRunConfig handles GET /api/v1/graphruns/{graphRunName}/config
+// Returns the configuration payload for a graph run, ready for replay via POST /graphruns
+//
+// @Summary Get graph run configuration
+// @Description Retrieve graph run configuration directly by KrknGraphRun CR name
+// @Tags graphruns
+// @Produce json
+// @Param graphRunName path string true "KrknGraphRun CR name"
+// @Success 200 {object} GraphRunCreateRequest "Graph run configuration"
+// @Failure 400 {object} ErrorResponse "Missing graph run name"
+// @Failure 401 {object} ErrorResponse "User authentication required"
+// @Failure 403 {object} ErrorResponse "Insufficient permissions"
+// @Failure 404 {object} ErrorResponse "GraphRun not found"
+// @Failure 500 {object} ErrorResponse "Internal server error"
+// @Security BearerAuth
+// @Router /graphruns/{graphRunName}/config [get]
+func (h *Handler) GetGraphRunConfig(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	logger := log.FromContext(ctx)
+
+	// Extract graphRunName from URL path
+	// Path format: /api/v1/graphruns/{graphRunName}/config
+	trimmed := strings.TrimPrefix(r.URL.Path, GraphRunsPath+"/")
+	graphRunName := strings.TrimSuffix(trimmed, "/config")
+	if graphRunName == "" {
+		writeJSONError(w, http.StatusBadRequest, ErrorResponse{
+			Error:   "bad_request",
+			Message: "Graph run name is required",
+		})
+		return
+	}
+
+	logger.V(1).Info("Graph run config request received", "graphRunName", graphRunName)
+
+	// Fetch KrknGraphRun CR
+	var graphRun krknv1alpha1.KrknGraphRun
+	if err := h.client.Get(ctx, types.NamespacedName{
+		Name:      graphRunName,
+		Namespace: h.namespace,
+	}, &graphRun); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			writeJSONError(w, http.StatusNotFound, ErrorResponse{
+				Error:   "not_found",
+				Message: fmt.Sprintf("GraphRun '%s' not found", graphRunName),
+			})
+		} else {
+			logger.Error(err, "Failed to get GraphRun", "graphRunName", graphRunName)
+			writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
+				Error:   "internal_error",
+				Message: "Failed to retrieve GraphRun",
+			})
+		}
+		return
+	}
+
+	// Validate RBAC permissions
+	claims := auth.GetClaimsFromContext(ctx)
+	if claims == nil {
+		writeJSONError(w, http.StatusUnauthorized, ErrorResponse{
+			Error:   "unauthorized",
+			Message: "User authentication required",
+		})
+		return
+	}
+
+	if !auth.IsAdmin(ctx) {
+		hasAccess, err := h.checkGraphRunGroupAccess(ctx, claims.UserID, &graphRun, groupauth.ActionView)
+		if err != nil {
+			logger.Error(err, "Failed to check graph run access", "userID", claims.UserID, "graphRunName", graphRunName)
+			writeJSONError(w, http.StatusInternalServerError, ErrorResponse{
+				Error:   "internal_error",
+				Message: "Failed to validate access permissions",
+			})
+			return
+		}
+		if !hasAccess {
+			logger.Info("User lacks permission to view graph run config",
+				"userID", claims.UserID,
+				"graphRunName", graphRunName)
+			writeJSONError(w, http.StatusForbidden, ErrorResponse{
+				Error:   "forbidden",
+				Message: "You do not have permission to view this graph run",
+			})
+			return
+		}
+	}
+
+	// Reconstruct the creation payload from the spec
+	payload := GraphRunCreateRequest{
+		Graph:           graphRun.Spec.Graph,
+		TargetRequestID: graphRun.Spec.TargetRequestID,
+		TargetClusters:  graphRun.Spec.TargetClusters,
+	}
+
+	logger.Info("Graph run config retrieved successfully",
+		"graphRunName", graphRunName,
+		"userID", claims.UserID)
+
+	writeJSON(w, http.StatusOK, payload)
+}

--- a/internal/api/run_config_handlers_test.go
+++ b/internal/api/run_config_handlers_test.go
@@ -37,7 +37,7 @@ import (
 
 func TestGetScenarioRunConfig_Success(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = krknv1alpha1.AddToScheme(scheme)
+	require.NoError(t, krknv1alpha1.AddToScheme(scheme))
 
 	scenarioRunName := "my-scenario-run"
 
@@ -113,7 +113,7 @@ func TestGetScenarioRunConfig_Success(t *testing.T) {
 
 func TestGetScenarioRunConfig_NotFound(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = krknv1alpha1.AddToScheme(scheme)
+	require.NoError(t, krknv1alpha1.AddToScheme(scheme))
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
@@ -143,7 +143,7 @@ func TestGetScenarioRunConfig_NotFound(t *testing.T) {
 
 func TestGetScenarioRunConfig_Unauthorized(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = krknv1alpha1.AddToScheme(scheme)
+	require.NoError(t, krknv1alpha1.AddToScheme(scheme))
 
 	scenarioRun := &krknv1alpha1.KrknScenarioRun{
 		ObjectMeta: metav1.ObjectMeta{
@@ -169,7 +169,6 @@ func TestGetScenarioRunConfig_Unauthorized(t *testing.T) {
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/scenarios/run/test-run/config", nil)
-	// No claims in context
 
 	w := httptest.NewRecorder()
 	handler.GetScenarioRunConfig(w, req)
@@ -184,7 +183,7 @@ func TestGetScenarioRunConfig_Unauthorized(t *testing.T) {
 
 func TestGetScenarioRunConfig_WithInlineAndRefFiles(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = krknv1alpha1.AddToScheme(scheme)
+	require.NoError(t, krknv1alpha1.AddToScheme(scheme))
 
 	scenarioRun := &krknv1alpha1.KrknScenarioRun{
 		ObjectMeta: metav1.ObjectMeta{
@@ -250,7 +249,7 @@ func TestGetScenarioRunConfig_WithInlineAndRefFiles(t *testing.T) {
 
 func TestGetGraphRunConfig_Success(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = krknv1alpha1.AddToScheme(scheme)
+	require.NoError(t, krknv1alpha1.AddToScheme(scheme))
 
 	graphRunName := "my-graph-run"
 
@@ -318,7 +317,7 @@ func TestGetGraphRunConfig_Success(t *testing.T) {
 
 func TestGetGraphRunConfig_NotFound(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = krknv1alpha1.AddToScheme(scheme)
+	require.NoError(t, krknv1alpha1.AddToScheme(scheme))
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
@@ -348,7 +347,7 @@ func TestGetGraphRunConfig_NotFound(t *testing.T) {
 
 func TestGetGraphRunConfig_Unauthorized(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = krknv1alpha1.AddToScheme(scheme)
+	require.NoError(t, krknv1alpha1.AddToScheme(scheme))
 
 	graphRun := &krknv1alpha1.KrknGraphRun{
 		ObjectMeta: metav1.ObjectMeta{
@@ -375,7 +374,6 @@ func TestGetGraphRunConfig_Unauthorized(t *testing.T) {
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/graphruns/test-graph/config", nil)
-	// No claims in context
 
 	w := httptest.NewRecorder()
 	handler.GetGraphRunConfig(w, req)
@@ -388,11 +386,11 @@ func TestGetGraphRunConfig_Unauthorized(t *testing.T) {
 	assert.Equal(t, "unauthorized", errResp.Error)
 }
 
-// --- Router integration tests ---
+// --- Router integration tests (v1) ---
 
 func TestScenariosRunRouter_ConfigEndpoint(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = krknv1alpha1.AddToScheme(scheme)
+	require.NoError(t, krknv1alpha1.AddToScheme(scheme))
 
 	scenarioRun := &krknv1alpha1.KrknScenarioRun{
 		ObjectMeta: metav1.ObjectMeta{
@@ -438,7 +436,7 @@ func TestScenariosRunRouter_ConfigEndpoint(t *testing.T) {
 
 func TestGraphRunsRouter_ConfigEndpoint(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = krknv1alpha1.AddToScheme(scheme)
+	require.NoError(t, krknv1alpha1.AddToScheme(scheme))
 
 	graphRun := &krknv1alpha1.KrknGraphRun{
 		ObjectMeta: metav1.ObjectMeta{
@@ -483,9 +481,106 @@ func TestGraphRunsRouter_ConfigEndpoint(t *testing.T) {
 	assert.Equal(t, "target-rt", payload.TargetRequestID)
 }
 
+// --- Router integration tests (v2 path normalization) ---
+
+func TestScenariosRunRouter_ConfigEndpoint_V2Path(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, krknv1alpha1.AddToScheme(scheme))
+
+	scenarioRun := &krknv1alpha1.KrknScenarioRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "v2-test-run",
+			Namespace: "krkn-operator-system",
+		},
+		Spec: krknv1alpha1.KrknScenarioRunSpec{
+			TargetRequestID: "target-v2",
+			TargetClusters:  map[string][]string{"krkn-operator": {"c1"}},
+			ScenarioName:    "scenario-v2",
+			ScenarioImage:   "quay.io/test:v2",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(scenarioRun).
+		Build()
+
+	handler := &Handler{
+		client:    fakeClient,
+		namespace: "krkn-operator-system",
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/scenarios/run/v2-test-run/config", nil)
+	claims := &auth.Claims{
+		UserID: "admin@test.com",
+		Role:   "admin",
+	}
+	ctx := context.WithValue(req.Context(), auth.UserClaimsKey, claims)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	handler.ScenariosRunRouter(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var payload ScenarioRunRequest
+	err := json.Unmarshal(w.Body.Bytes(), &payload)
+	require.NoError(t, err)
+	assert.Equal(t, "scenario-v2", payload.ScenarioName)
+}
+
+func TestGraphRunsRouter_ConfigEndpoint_V2Path(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, krknv1alpha1.AddToScheme(scheme))
+
+	graphRun := &krknv1alpha1.KrknGraphRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "v2-test-graph",
+			Namespace: "krkn-operator-system",
+		},
+		Spec: krknv1alpha1.KrknGraphRunSpec{
+			Graph: map[string]krknv1alpha1.GraphScenarioNode{
+				"n1": {Name: "s1", Image: "img:1"},
+			},
+			TargetRequestID: "target-v2",
+			TargetClusters:  map[string][]string{"krkn-operator": {"c1"}},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(graphRun).
+		Build()
+
+	handler := &Handler{
+		client:    fakeClient,
+		namespace: "krkn-operator-system",
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/graphruns/v2-test-graph/config", nil)
+	claims := &auth.Claims{
+		UserID: "admin@test.com",
+		Role:   "admin",
+	}
+	ctx := context.WithValue(req.Context(), auth.UserClaimsKey, claims)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	handler.GraphRunsRouter(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var payload GraphRunCreateRequest
+	err := json.Unmarshal(w.Body.Bytes(), &payload)
+	require.NoError(t, err)
+	assert.Equal(t, "target-v2", payload.TargetRequestID)
+}
+
+// --- Method not allowed tests ---
+
 func TestScenariosRunRouter_ConfigMethodNotAllowed(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = krknv1alpha1.AddToScheme(scheme)
+	require.NoError(t, krknv1alpha1.AddToScheme(scheme))
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	handler := &Handler{client: fakeClient, namespace: "krkn-operator-system"}
 
@@ -502,7 +597,7 @@ func TestScenariosRunRouter_ConfigMethodNotAllowed(t *testing.T) {
 
 func TestGraphRunsRouter_ConfigMethodNotAllowed(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = krknv1alpha1.AddToScheme(scheme)
+	require.NoError(t, krknv1alpha1.AddToScheme(scheme))
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	handler := &Handler{client: fakeClient, namespace: "krkn-operator-system"}
 

--- a/internal/api/run_config_handlers_test.go
+++ b/internal/api/run_config_handlers_test.go
@@ -1,0 +1,518 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	krknv1alpha1 "github.com/krkn-chaos/krkn-operator/api/v1alpha1"
+	"github.com/krkn-chaos/krkn-operator/pkg/auth"
+)
+
+// --- ScenarioRun Config Tests ---
+
+func TestGetScenarioRunConfig_Success(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = krknv1alpha1.AddToScheme(scheme)
+
+	scenarioRunName := "my-scenario-run"
+
+	scenarioRun := &krknv1alpha1.KrknScenarioRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      scenarioRunName,
+			Namespace: "krkn-operator-system",
+		},
+		Spec: krknv1alpha1.KrknScenarioRunSpec{
+			TargetRequestID: "target-123",
+			TargetClusters: map[string][]string{
+				"krkn-operator": {"cluster1", "cluster2"},
+			},
+			ScenarioName:  "dummy-scenario",
+			ScenarioImage: "quay.io/krkn-chaos/krkn-hub:dummy-scenario",
+			Environment: map[string]string{
+				"EXIT_STATUS": "0",
+			},
+			KubeconfigPath: "/home/krkn/.kube/config",
+			Files: []krknv1alpha1.FileMount{
+				{
+					Name:      "config.yaml",
+					Content:   "base64content",
+					MountPath: "/etc/krkn/config.yaml",
+					FileID:    "file-uuid-001",
+				},
+			},
+			RegistryName: "my-registry",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(scenarioRun).
+		Build()
+
+	handler := &Handler{
+		client:    fakeClient,
+		namespace: "krkn-operator-system",
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/scenarios/run/"+scenarioRunName+"/config", nil)
+	claims := &auth.Claims{
+		UserID: "admin@test.com",
+		Role:   "admin",
+	}
+	ctx := context.WithValue(req.Context(), auth.UserClaimsKey, claims)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	handler.GetScenarioRunConfig(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var payload ScenarioRunRequest
+	err := json.Unmarshal(w.Body.Bytes(), &payload)
+	require.NoError(t, err)
+
+	assert.Equal(t, "target-123", payload.TargetRequestID)
+	assert.Equal(t, "dummy-scenario", payload.ScenarioName)
+	assert.Equal(t, "quay.io/krkn-chaos/krkn-hub:dummy-scenario", payload.ScenarioImage)
+	assert.Equal(t, map[string][]string{"krkn-operator": {"cluster1", "cluster2"}}, payload.TargetClusters)
+	assert.Equal(t, map[string]string{"EXIT_STATUS": "0"}, payload.Environment)
+	assert.Equal(t, "/home/krkn/.kube/config", payload.KubeconfigPath)
+
+	require.Len(t, payload.FileReferences, 1)
+	assert.Equal(t, "file-uuid-001", payload.FileReferences[0].FileID)
+	assert.Equal(t, "/etc/krkn/config.yaml", payload.FileReferences[0].MountPath)
+
+	require.NotNil(t, payload.RegistryName)
+	assert.Equal(t, "my-registry", *payload.RegistryName)
+}
+
+func TestGetScenarioRunConfig_NotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = krknv1alpha1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	handler := &Handler{
+		client:    fakeClient,
+		namespace: "krkn-operator-system",
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/scenarios/run/nonexistent/config", nil)
+	claims := &auth.Claims{
+		UserID: "admin@test.com",
+		Role:   "admin",
+	}
+	ctx := context.WithValue(req.Context(), auth.UserClaimsKey, claims)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	handler.GetScenarioRunConfig(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	var errResp ErrorResponse
+	err := json.Unmarshal(w.Body.Bytes(), &errResp)
+	require.NoError(t, err)
+	assert.Equal(t, "not_found", errResp.Error)
+}
+
+func TestGetScenarioRunConfig_Unauthorized(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = krknv1alpha1.AddToScheme(scheme)
+
+	scenarioRun := &krknv1alpha1.KrknScenarioRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-run",
+			Namespace: "krkn-operator-system",
+		},
+		Spec: krknv1alpha1.KrknScenarioRunSpec{
+			TargetRequestID: "target-123",
+			TargetClusters:  map[string][]string{"krkn-operator": {"cluster1"}},
+			ScenarioName:    "dummy-scenario",
+			ScenarioImage:   "quay.io/test:latest",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(scenarioRun).
+		Build()
+
+	handler := &Handler{
+		client:    fakeClient,
+		namespace: "krkn-operator-system",
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/scenarios/run/test-run/config", nil)
+	// No claims in context
+
+	w := httptest.NewRecorder()
+	handler.GetScenarioRunConfig(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	var errResp ErrorResponse
+	err := json.Unmarshal(w.Body.Bytes(), &errResp)
+	require.NoError(t, err)
+	assert.Equal(t, "unauthorized", errResp.Error)
+}
+
+func TestGetScenarioRunConfig_WithInlineAndRefFiles(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = krknv1alpha1.AddToScheme(scheme)
+
+	scenarioRun := &krknv1alpha1.KrknScenarioRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mixed-files-run",
+			Namespace: "krkn-operator-system",
+		},
+		Spec: krknv1alpha1.KrknScenarioRunSpec{
+			TargetRequestID: "target-456",
+			TargetClusters:  map[string][]string{"krkn-operator": {"cluster1"}},
+			ScenarioName:    "test-scenario",
+			ScenarioImage:   "quay.io/test:latest",
+			Files: []krknv1alpha1.FileMount{
+				{
+					Name:      "inline.yaml",
+					Content:   "inline-content",
+					MountPath: "/tmp/inline.yaml",
+				},
+				{
+					Name:      "ref.yaml",
+					Content:   "ref-content",
+					MountPath: "/tmp/ref.yaml",
+					FileID:    "uuid-ref-001",
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(scenarioRun).
+		Build()
+
+	handler := &Handler{
+		client:    fakeClient,
+		namespace: "krkn-operator-system",
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/scenarios/run/mixed-files-run/config", nil)
+	claims := &auth.Claims{
+		UserID: "admin@test.com",
+		Role:   "admin",
+	}
+	ctx := context.WithValue(req.Context(), auth.UserClaimsKey, claims)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	handler.GetScenarioRunConfig(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var payload ScenarioRunRequest
+	err := json.Unmarshal(w.Body.Bytes(), &payload)
+	require.NoError(t, err)
+
+	require.Len(t, payload.Files, 1)
+	assert.Equal(t, "inline.yaml", payload.Files[0].Name)
+
+	require.Len(t, payload.FileReferences, 1)
+	assert.Equal(t, "uuid-ref-001", payload.FileReferences[0].FileID)
+}
+
+// --- GraphRun Config Tests ---
+
+func TestGetGraphRunConfig_Success(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = krknv1alpha1.AddToScheme(scheme)
+
+	graphRunName := "my-graph-run"
+
+	graphRun := &krknv1alpha1.KrknGraphRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      graphRunName,
+			Namespace: "krkn-operator-system",
+		},
+		Spec: krknv1alpha1.KrknGraphRunSpec{
+			Graph: map[string]krknv1alpha1.GraphScenarioNode{
+				"node-1": {
+					Name:  "scenario-a",
+					Image: "quay.io/krkn-chaos/krkn-hub:scenario-a",
+					Env:   map[string]string{"EXIT_STATUS": "0"},
+				},
+				"node-2": {
+					Name:      "scenario-b",
+					Image:     "quay.io/krkn-chaos/krkn-hub:scenario-b",
+					DependsOn: strPtr("node-1"),
+				},
+			},
+			TargetRequestID: "target-graph-123",
+			TargetClusters: map[string][]string{
+				"krkn-operator": {"cluster1"},
+			},
+			OwnerUserID: "owner@test.com",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(graphRun).
+		Build()
+
+	handler := &Handler{
+		client:    fakeClient,
+		namespace: "krkn-operator-system",
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/graphruns/"+graphRunName+"/config", nil)
+	claims := &auth.Claims{
+		UserID: "admin@test.com",
+		Role:   "admin",
+	}
+	ctx := context.WithValue(req.Context(), auth.UserClaimsKey, claims)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	handler.GetGraphRunConfig(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var payload GraphRunCreateRequest
+	err := json.Unmarshal(w.Body.Bytes(), &payload)
+	require.NoError(t, err)
+
+	assert.Equal(t, "target-graph-123", payload.TargetRequestID)
+	assert.Equal(t, map[string][]string{"krkn-operator": {"cluster1"}}, payload.TargetClusters)
+
+	require.Len(t, payload.Graph, 2)
+	assert.Equal(t, "scenario-a", payload.Graph["node-1"].Name)
+	assert.Equal(t, "scenario-b", payload.Graph["node-2"].Name)
+	assert.Equal(t, "node-1", *payload.Graph["node-2"].DependsOn)
+}
+
+func TestGetGraphRunConfig_NotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = krknv1alpha1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	handler := &Handler{
+		client:    fakeClient,
+		namespace: "krkn-operator-system",
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/graphruns/nonexistent/config", nil)
+	claims := &auth.Claims{
+		UserID: "admin@test.com",
+		Role:   "admin",
+	}
+	ctx := context.WithValue(req.Context(), auth.UserClaimsKey, claims)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	handler.GetGraphRunConfig(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	var errResp ErrorResponse
+	err := json.Unmarshal(w.Body.Bytes(), &errResp)
+	require.NoError(t, err)
+	assert.Equal(t, "not_found", errResp.Error)
+}
+
+func TestGetGraphRunConfig_Unauthorized(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = krknv1alpha1.AddToScheme(scheme)
+
+	graphRun := &krknv1alpha1.KrknGraphRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-graph",
+			Namespace: "krkn-operator-system",
+		},
+		Spec: krknv1alpha1.KrknGraphRunSpec{
+			Graph: map[string]krknv1alpha1.GraphScenarioNode{
+				"node-1": {Name: "s1", Image: "img:1"},
+			},
+			TargetRequestID: "target-123",
+			TargetClusters:  map[string][]string{"krkn-operator": {"cluster1"}},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(graphRun).
+		Build()
+
+	handler := &Handler{
+		client:    fakeClient,
+		namespace: "krkn-operator-system",
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/graphruns/test-graph/config", nil)
+	// No claims in context
+
+	w := httptest.NewRecorder()
+	handler.GetGraphRunConfig(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	var errResp ErrorResponse
+	err := json.Unmarshal(w.Body.Bytes(), &errResp)
+	require.NoError(t, err)
+	assert.Equal(t, "unauthorized", errResp.Error)
+}
+
+// --- Router integration tests ---
+
+func TestScenariosRunRouter_ConfigEndpoint(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = krknv1alpha1.AddToScheme(scheme)
+
+	scenarioRun := &krknv1alpha1.KrknScenarioRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "router-test-run",
+			Namespace: "krkn-operator-system",
+		},
+		Spec: krknv1alpha1.KrknScenarioRunSpec{
+			TargetRequestID: "target-rt",
+			TargetClusters:  map[string][]string{"krkn-operator": {"c1"}},
+			ScenarioName:    "scenario-rt",
+			ScenarioImage:   "quay.io/test:rt",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(scenarioRun).
+		Build()
+
+	handler := &Handler{
+		client:    fakeClient,
+		namespace: "krkn-operator-system",
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/scenarios/run/router-test-run/config", nil)
+	claims := &auth.Claims{
+		UserID: "admin@test.com",
+		Role:   "admin",
+	}
+	ctx := context.WithValue(req.Context(), auth.UserClaimsKey, claims)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	handler.ScenariosRunRouter(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var payload ScenarioRunRequest
+	err := json.Unmarshal(w.Body.Bytes(), &payload)
+	require.NoError(t, err)
+	assert.Equal(t, "scenario-rt", payload.ScenarioName)
+}
+
+func TestGraphRunsRouter_ConfigEndpoint(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = krknv1alpha1.AddToScheme(scheme)
+
+	graphRun := &krknv1alpha1.KrknGraphRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "router-test-graph",
+			Namespace: "krkn-operator-system",
+		},
+		Spec: krknv1alpha1.KrknGraphRunSpec{
+			Graph: map[string]krknv1alpha1.GraphScenarioNode{
+				"n1": {Name: "s1", Image: "img:1"},
+			},
+			TargetRequestID: "target-rt",
+			TargetClusters:  map[string][]string{"krkn-operator": {"c1"}},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(graphRun).
+		Build()
+
+	handler := &Handler{
+		client:    fakeClient,
+		namespace: "krkn-operator-system",
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/graphruns/router-test-graph/config", nil)
+	claims := &auth.Claims{
+		UserID: "admin@test.com",
+		Role:   "admin",
+	}
+	ctx := context.WithValue(req.Context(), auth.UserClaimsKey, claims)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	handler.GraphRunsRouter(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var payload GraphRunCreateRequest
+	err := json.Unmarshal(w.Body.Bytes(), &payload)
+	require.NoError(t, err)
+	assert.Equal(t, "target-rt", payload.TargetRequestID)
+}
+
+func TestScenariosRunRouter_ConfigMethodNotAllowed(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = krknv1alpha1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	handler := &Handler{client: fakeClient, namespace: "krkn-operator-system"}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/scenarios/run/some-run/config", nil)
+	claims := &auth.Claims{UserID: "admin@test.com", Role: "admin"}
+	ctx := context.WithValue(req.Context(), auth.UserClaimsKey, claims)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	handler.ScenariosRunRouter(w, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}
+
+func TestGraphRunsRouter_ConfigMethodNotAllowed(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = krknv1alpha1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	handler := &Handler{client: fakeClient, namespace: "krkn-operator-system"}
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/graphruns/some-graph/config", nil)
+	claims := &auth.Claims{UserID: "admin@test.com", Role: "admin"}
+	ctx := context.WithValue(req.Context(), auth.UserClaimsKey, claims)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	handler.GraphRunsRouter(w, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/scenarios/run/{scenarioRunName}/config` endpoint to retrieve scenario run configuration directly by CR name
- Add `GET /api/v1/graphruns/{graphRunName}/config` endpoint to retrieve graph run configuration directly by CR name
- Both endpoints use existing RBAC patterns (admin bypass + group-based permission checks) and are accessible via v2 paths

## Test plan
- [x] 11 unit tests covering success, not found, unauthorized, mixed file types, router integration, and method not allowed
- [x] All existing API tests pass with no regressions
- [ ] Manual test: call `GET /api/v1/scenarios/run/{name}/config` with a valid CR name
- [ ] Manual test: call `GET /api/v1/graphruns/{name}/config` with a valid CR name
- [ ] Verify 403 for non-admin user without group permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)