### PR TITLE
fixing missing customRunName in chart crd

### DIFF
--- a/charts/krkn-operator/crds/krkn.krkn-chaos.dev_krknscenarioruns.yaml
+++ b/charts/krkn-operator/crds/krkn.krkn-chaos.dev_krknscenarioruns.yaml
@@ -57,6 +57,10 @@ spec:
           spec:
             description: KrknScenarioRunSpec defines the desired state of KrknScenarioRun
             properties:
+              customRunName:
+                description: CustomRunName is a user-provided label for the run, displayed
+                  in the console
+                type: string
               environment:
                 additionalProperties:
                   type: string


### PR DESCRIPTION
`charts/krkn-operator/crds/krkn.krkn-chaos.dev_krknscenarioruns.yaml` was missing `customRunName`, so on a Helm-installed cluster the API server prunes the field and the console reads back an empty run name.

Adds the four missing lines. The chart CRD is now identical to `config/crd/bases`.

Please refer to #85 for the impact, the affected releases and the note for existing installs.

Found while adding krkn-operator coverage for the docs sync bot, krkn-chaos/website#320.

Fixes #85
