### PR TITLE
fixing ci not catching stale generated manifests

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -20,6 +20,13 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Verify generated manifests are up to date
+        run: |
+          make manifests
+          # intent-to-add, so a brand new CRD file is caught too, git diff ignores untracked files
+          git add -AN config/crd/bases charts/krkn-operator/crds
+          git diff --exit-code config/crd/bases charts/krkn-operator/crds
+
       - name: Run gosec security scanner
         uses: securego/gosec@master
         with:

--- a/Makefile
+++ b/Makefile
@@ -107,9 +107,11 @@ help: ## Display this help.
 
 ##@ Development
 
+# the helm chart ships its own copy of the CRDs, generate it rather than maintaining it by hand
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd:allowDangerousTypes=true webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	cp config/crd/bases/*.yaml charts/krkn-operator/crds/
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.


### PR DESCRIPTION
Nothing in CI verifies that `config/crd/bases` still matches the Go types, so a commit that edits `api/v1alpha1` without running `make manifests` passes every check today.

Adds one step to `pr-checks.yml`, placed right after `setup-go` so it fails fast. Standard kubebuilder practice, and it fails with a readable diff.

Please refer to #86 for the full reasoning.

Found while adding krkn-operator coverage for the docs sync bot, krkn-chaos/website#320.

Fixes #86
