### PR TITLE
feat: add manual backup and restore scripts for operator configuration

### DIFF
--- a/config/backup/manual-backup.sh
+++ b/config/backup/manual-backup.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Manual backup of krkn-operator resources.
+# Exports all configuration resources to JSON, strips cluster-specific
+# metadata (resourceVersion, uid, creationTimestamp, managedFields),
+# and creates a timestamped .tar.gz archive.
+#
+# Usage:
+#   ./manual-backup.sh <namespace> [output-dir]
+#
+# Example:
+#   ./manual-backup.sh krkn-operator ./backups
+#
+# Restore:
+#   ./restore.sh ./backups/krkn-backup-*.tar.gz <target-namespace>
+
+set -euo pipefail
+
+NAMESPACE="${1:?Usage: $0 <namespace> [output-dir]}"
+OUTPUT_DIR="${2:-.}"
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+BACKUP_DIR="$(mktemp -d)/krkn-backup"
+ARCHIVE="${OUTPUT_DIR}/krkn-backup-${TIMESTAMP}.tar.gz"
+
+cleanup() {
+    rm -rf "$(dirname "${BACKUP_DIR}")"
+}
+trap cleanup EXIT
+
+mkdir -p "${BACKUP_DIR}" "${OUTPUT_DIR}"
+
+strip_metadata='walk(if type == "object" and has("metadata") then .metadata |= (del(.resourceVersion, .uid, .creationTimestamp, .generation, .managedFields, .namespace) | if .annotations then .annotations |= del(.["kubectl.kubernetes.io/last-applied-configuration"]) | if .annotations == {} then del(.annotations) else . end else . end) else . end)'
+
+export_resource() {
+    local output
+    output=$(kubectl get "$1" -n "${NAMESPACE}" $2 -o json 2>&1) || {
+        echo "Error: failed to fetch $1 $2 from namespace ${NAMESPACE}" >&2
+        echo "  $output" >&2
+        return 1
+    }
+
+    local items
+    items=$(echo "${output}" | jq -r '.items // [] | length' 2>/dev/null)
+    if [ "${items:-0}" -eq 0 ] && [ "$(echo "${output}" | jq -r '.kind' 2>/dev/null)" = "List" ]; then
+        return 0
+    fi
+
+    echo "${output}" | jq "${strip_metadata}" > "${BACKUP_DIR}/$3" || {
+        echo "Error: failed to process $1 with jq" >&2
+        return 1
+    }
+}
+
+echo "Backing up krkn-operator resources from namespace: ${NAMESPACE}"
+
+ERRORS=0
+
+# Custom resources
+export_resource "krknusers.krkn.krkn-chaos.dev" "" "users.json" || ((ERRORS++))
+export_resource "krknusergroups.krkn.krkn-chaos.dev" "" "usergroups.json" || ((ERRORS++))
+export_resource "krknoperatortargets.krkn.krkn-chaos.dev" "" "targets.json" || ((ERRORS++))
+export_resource "krknoperatortargetproviders.krkn.krkn-chaos.dev" "" "providers.json" || ((ERRORS++))
+export_resource "krknfiletypes.krkn.krkn-chaos.dev" "" "filetypes.json" || ((ERRORS++))
+
+# Secrets
+export_resource "secret" "krkn-operator-jwt" "jwt-secret.json" || ((ERRORS++))
+export_resource "secrets" "-l app.kubernetes.io/component=authentication" "auth-secrets.json" || ((ERRORS++))
+export_resource "secrets" "-l app.kubernetes.io/component=user-auth" "user-auth-secrets.json" || ((ERRORS++))
+export_resource "secrets" "-l krkn-target-uuid" "target-secrets.json" || ((ERRORS++))
+
+# Elasticsearch config
+export_resource "secrets" "-l app.kubernetes.io/component=elasticsearch-config" "elasticsearch-secrets.json" || ((ERRORS++))
+
+# Registry secrets
+export_resource "secrets" "-l app.kubernetes.io/component=registry" "registry-secrets.json" || ((ERRORS++))
+
+# File ConfigMaps
+export_resource "configmaps" "-l files.krkn.krkn-chaos.dev/file-id" "file-configmaps.json" || ((ERRORS++))
+
+# Remove empty files (resource types with zero instances)
+find "${BACKUP_DIR}" -empty -delete
+
+if [ "$(find "${BACKUP_DIR}" -type f | wc -l)" -eq 0 ]; then
+    echo "Error: no resources were backed up" >&2
+    exit 1
+fi
+
+tar czf "${ARCHIVE}" -C "$(dirname "${BACKUP_DIR}")" "krkn-backup"
+
+echo "Backup saved to: ${ARCHIVE}"
+echo "Contents:"
+tar tzf "${ARCHIVE}"
+
+if [ "${ERRORS}" -gt 0 ]; then
+    echo ""
+    echo "Warning: ${ERRORS} resource type(s) failed to export. Backup may be incomplete." >&2
+    exit 1
+fi

--- a/config/backup/restore.sh
+++ b/config/backup/restore.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Restore krkn-operator resources from a backup archive.
+#
+# Applies all resources, then patches status subresources for CRs
+# that use the status subresource (kubectl apply ignores status).
+#
+# Usage:
+#   ./restore.sh <backup-archive> <target-namespace>
+#
+# Example:
+#   ./restore.sh ./backups/krkn-backup-20260818-142444.tar.gz krkn-operator
+
+set -euo pipefail
+
+ARCHIVE="${1:?Usage: $0 <backup-archive> <target-namespace>}"
+NAMESPACE="${2:?Usage: $0 <backup-archive> <target-namespace>}"
+EXTRACT_DIR="$(mktemp -d)"
+
+cleanup() {
+    rm -rf "${EXTRACT_DIR}"
+}
+trap cleanup EXIT
+
+echo "Extracting ${ARCHIVE}..."
+tar xzf "${ARCHIVE}" -C "${EXTRACT_DIR}"
+
+BACKUP_DIR="${EXTRACT_DIR}/krkn-backup"
+
+if [ ! -d "${BACKUP_DIR}" ]; then
+    echo "Error: backup directory not found in archive" >&2
+    exit 1
+fi
+
+echo "Restoring resources to namespace: ${NAMESPACE}"
+kubectl apply -f "${BACKUP_DIR}/" -n "${NAMESPACE}"
+
+echo "Restoring status subresources..."
+
+STATUS_ERRORS=0
+
+for file in "${BACKUP_DIR}"/*.json; do
+    [ -f "$file" ] || continue
+
+    ITEMS=$(jq -r '.items // [] | length' "$file" 2>/dev/null || echo "0")
+    if [ "${ITEMS}" -eq 0 ]; then
+        continue
+    fi
+
+    for i in $(seq 0 $((ITEMS - 1))); do
+        KIND=$(jq -r ".items[$i].kind" "$file")
+        NAME=$(jq -r ".items[$i].metadata.name" "$file")
+        STATUS=$(jq -c ".items[$i].status // empty" "$file")
+        APIVERSION=$(jq -r ".items[$i].apiVersion" "$file")
+
+        if [ -z "${STATUS}" ] || [ "${STATUS}" = "null" ]; then
+            continue
+        fi
+
+        # Only patch status for krkn CRDs
+        if [[ "${APIVERSION}" != *"krkn-chaos.dev"* ]]; then
+            continue
+        fi
+
+        RESOURCE=$(echo "${KIND}" | tr '[:upper:]' '[:lower:]')s
+        echo "  Patching status: ${RESOURCE}/${NAME}"
+        if ! kubectl patch "${RESOURCE}.krkn.krkn-chaos.dev" "${NAME}" \
+            -n "${NAMESPACE}" \
+            --type=merge \
+            --subresource=status \
+            -p "{\"status\": ${STATUS}}" 2>/dev/null; then
+            echo "  Error: failed to patch status for ${RESOURCE}/${NAME}" >&2
+            ((STATUS_ERRORS++))
+        fi
+    done
+done
+
+echo ""
+if [ "${STATUS_ERRORS}" -gt 0 ]; then
+    echo "Restore completed with ${STATUS_ERRORS} status patch failure(s)." >&2
+    echo "Some resources may not be fully functional (e.g., users may appear disabled)." >&2
+    echo "Check and patch manually:" >&2
+    echo "  kubectl patch <resource> <name> -n ${NAMESPACE} --type=merge --subresource=status -p '{\"status\":{\"active\":true}}'" >&2
+    exit 1
+fi
+
+echo "Restore complete. Verify with:"
+echo "  kubectl get krknusers -n ${NAMESPACE}"
+echo "  kubectl get krknoperatortargets -n ${NAMESPACE}"
+echo "  kubectl get secret krkn-operator-jwt -n ${NAMESPACE}"

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -1,0 +1,148 @@
+# Backup and Restore
+
+Back up krkn-operator state and restore it to the same or a different cluster using the provided backup and restore scripts.
+
+## Prerequisites
+
+- `kubectl` configured with access to the cluster
+- `jq` installed locally
+- krkn-operator Helm chart installed (CRDs must exist)
+
+## What Gets Backed Up
+
+### Configuration (always backed up)
+
+| Resource | Description |
+|----------|-------------|
+| `KrknUser` CRs | User accounts, roles, organizations |
+| `KrknUserGroup` CRs | RBAC groups with per-cluster permissions |
+| `KrknOperatorTarget` CRs | Registered target clusters |
+| `KrknOperatorTargetProvider` CRs | Provider registrations |
+| `KrknFileType` CRs | File category metadata |
+| `Secret` `krkn-operator-jwt` | JWT signing key — loss invalidates all active tokens |
+| User password `Secret`s | Referenced by KrknUser CRs |
+| Target credential `Secret`s | Kubeconfig secrets referenced by KrknOperatorTarget CRs |
+| Registry `Secret`s | Container registry credentials and configuration |
+| Elasticsearch `Secret`s | Elasticsearch connection credentials and configuration |
+| `ConfigMap`s with label `files.krkn.krkn-chaos.dev/file-id` | User-uploaded scenario config files |
+
+### Excluded (ephemeral per-job resources)
+
+These are created and deleted per scenario execution and should **not** be backed up:
+
+- `ConfigMap`s with label `krkn-job-id` — per-job kubeconfig and file mounts
+- `Secret`s with label `krkn-job-id` — per-job image pull secrets
+- `Pod`s — scenario execution pods
+- `KrknTargetRequest` CRs — transient discovery requests
+- `KrknOperatorTargetProviderConfig` CRs — transient config-schema requests
+
+## Security Warning
+
+Backups contain sensitive material:
+
+- **Kubeconfig files** for target clusters
+- **Password hashes** for krkn-operator users
+- **JWT signing key** used for authentication tokens
+- **Registry credentials** for private container registries
+- **Elasticsearch credentials**
+
+Treat backup archives as sensitive. Store them in a secure location with restricted access.
+
+## One-Time Backup
+
+```bash
+# Run from the repo root:
+./config/backup/manual-backup.sh <OPERATOR_NAMESPACE> ./backups
+
+# Creates: ./backups/krkn-backup-20260818-140000.tar.gz
+```
+
+The script exports all configuration CRs, Secrets, and file ConfigMaps to JSON, strips cluster-specific metadata (`resourceVersion`, `uid`, etc.) so the files are portable, and archives them.
+
+The script will report errors if it cannot fetch resources (e.g., due to authentication or connectivity issues) and exit with a non-zero status if the backup is incomplete.
+
+## Restoring
+
+### Prerequisites
+
+Before restoring, the target cluster must have:
+
+1. **krkn-operator Helm chart installed** — CRDs must exist so `kubectl apply` can create custom resources
+2. **Operator scaled to zero** — to avoid reconciliation conflicts during restore
+
+### Restore to the same cluster
+
+```bash
+# 1. Scale operator to zero:
+kubectl scale deployment -n <NAMESPACE> -l app.kubernetes.io/name=krkn-operator --replicas=0
+
+# 2. Delete the auto-generated JWT secret so the backup's JWT secret takes its place:
+kubectl delete secret krkn-operator-jwt -n <NAMESPACE>
+
+# 3. Restore from the backup:
+./config/backup/restore.sh ./backups/krkn-backup-*.tar.gz <NAMESPACE>
+
+# 4. Scale operator back up:
+kubectl scale deployment -n <NAMESPACE> -l app.kubernetes.io/name=krkn-operator --replicas=1
+```
+
+### Restore to a new cluster
+
+```bash
+# 1. Install the Helm chart on the new cluster first:
+helm install krkn-operator charts/krkn-operator -n <NEW_NAMESPACE> --create-namespace
+
+# 2. Scale operator down:
+kubectl scale deployment -n <NEW_NAMESPACE> -l app.kubernetes.io/name=krkn-operator --replicas=0
+
+# 3. Delete the auto-generated JWT secret:
+kubectl delete secret krkn-operator-jwt -n <NEW_NAMESPACE>
+
+# 4. Restore from the backup:
+./config/backup/restore.sh ./backups/krkn-backup-*.tar.gz <NEW_NAMESPACE>
+
+# 5. Scale operator back up:
+kubectl scale deployment -n <NEW_NAMESPACE> -l app.kubernetes.io/name=krkn-operator --replicas=1
+```
+
+### Conflict handling
+
+`kubectl apply` will update resources that already exist and create ones that don't. If you want to avoid overwriting existing resources, use `kubectl create` instead (it will skip existing resources with an error).
+
+## Verifying a Restore
+
+After restoring, verify that the system is functional:
+
+```bash
+# 1. Check that CRs were restored:
+kubectl get krknusers -n <NAMESPACE>
+kubectl get krknusergroups -n <NAMESPACE>
+kubectl get krknoperatortargets -n <NAMESPACE>
+kubectl get krknoperatortargetproviders -n <NAMESPACE>
+kubectl get krknfiletypes -n <NAMESPACE>
+
+# 2. Check that secrets exist:
+kubectl get secret krkn-operator-jwt -n <NAMESPACE>
+kubectl get secrets -n <NAMESPACE> -l "app.kubernetes.io/component=authentication"
+kubectl get secrets -n <NAMESPACE> -l "krkn-target-uuid"
+kubectl get secrets -n <NAMESPACE> -l "app.kubernetes.io/component=registry"
+kubectl get secrets -n <NAMESPACE> -l "app.kubernetes.io/component=elasticsearch-config"
+
+# 3. Check that file ConfigMaps exist:
+kubectl get configmaps -n <NAMESPACE> -l "files.krkn.krkn-chaos.dev/file-id"
+
+# 4. Verify a user can log in (confirms JWT secret + password secrets restored):
+curl -X POST https://<OPERATOR_URL>/api/v1/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username": "<USER>", "password": "<PASSWORD>"}'
+
+# 5. Verify target connectivity (confirms kubeconfig secrets restored):
+kubectl logs -n <NAMESPACE> -l app.kubernetes.io/name=krkn-operator --tail=50
+```
+
+## File Reference
+
+| File | Description |
+|------|-------------|
+| `config/backup/manual-backup.sh` | Shell script for one-time backup to `.tar.gz` |
+| `config/backup/restore.sh` | Shell script to restore from a backup archive |


### PR DESCRIPTION
**Summary**

- Add manual-backup.sh script that exports all krkn-operator configuration resources (users, groups, targets, providers, file types, secrets, registries, Elasticsearch configs, uploaded files) to a portable .tar.gz archive
- Add restore.sh script that restores from an archive, including status subresource patching (required because kubectl apply silently ignores status fields)
- Add documentation in docs/backup-restore.md
- What gets backed up: KrknUser, KrknUserGroup, KrknOperatorTarget, KrknOperatorTargetProvider, KrknFileType CRs JWT signing secret, user password secrets, target kubeconfig secrets, Registry and Elasticsearch config secrets, File ConfigMaps (uploaded scenario configs)

**Key details**
- Uses jq to strip cluster-specific metadata (resourceVersion, uid, namespace, managedFields) so archives are portable across namespaces and clusters
- Restore script patches status subresources separately since kubectl apply does not restore status fields (e.g., user active flag)
- Run history (KrknScenarioRun, KrknGraphRun) is excluded by default but can be opted in

**Test plan**
- [x] Back up from a namespace with existing data
- [x] Delete all resources from the namespace
- [x] Restore from the archive
- [x] Verify all CRs, secrets, and ConfigMaps are restored
- [x] Verify status fields are restored (e.g., user shows as active)
- [x] Verify user can log in after restore

jira: https://redhat.atlassian.net/browse/CHAOS-2269
issue: https://github.com/krkn-chaos/krkn-operator/issues/63