### PR TITLE
dispatch the website docs sync when a crd changes

### DIFF
--- a/.github/workflows/trigger-docs-sync.yml
+++ b/.github/workflows/trigger-docs-sync.yml
@@ -1,0 +1,41 @@
+name: Trigger docs sync
+
+# Part of the krkn docs-sync bot: krkn-chaos/website#320.
+#
+#   Watches   config/crd/bases/**, which owns the operator's API surface
+#   Sends     "operator" to Doc Sync on krkn-chaos/website
+#   Changes   nothing here: its app token is scoped to the website
+#
+# push, not pull_request: a fork PR gets no secrets, and a merge is a push anyway.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - config/crd/bases/**
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint a website-scoped app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.DOC_SYNC_BOT_APP_ID }}
+          private-key: ${{ secrets.DOC_SYNC_BOT_APP_PRIVATE_KEY }}
+          owner: krkn-chaos
+          repositories: website
+
+      - name: Dispatch doc-sync on the website
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          # One target for all 9 kinds: they live in one directory and
+          # regenerating all of them costs nothing.
+          gh workflow run doc-sync.lock.yml \
+            --repo krkn-chaos/website \
+            -f scenarios="operator"


### PR DESCRIPTION
This is part of https://github.com/krkn-chaos/website/issues/320, the Automated Documentation Sync Bot, an LFX mentorship project.
This PR covers the piece that lives in this repo.

For more details [refer](https://github.com/krkn-chaos/krkn-operator/issues/91)
Closes:- #91